### PR TITLE
ドキュメント作成リマインドをコミット前に変更

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,6 +92,17 @@
     "additionalDirectories": []
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | jq -r '.command // empty' 2>/dev/null | grep -q 'git commit'; then echo '📝 ドキュメント作成を確認: ADR / 技術ノート / セッションログ（該当する場合）'; fi"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
@@ -99,16 +110,6 @@
           {
             "type": "command",
             "command": "file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); if [[ \"$file_path\" == *.rs ]]; then cargo fmt --quiet -- \"$file_path\" 2>/dev/null || true; fi"
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '📝 ドキュメント作成を確認: ADR / 技術ノート / セッションログ（該当する場合）'"
           }
         ]
       }

--- a/docs/05_技術ノート/ClaudeCode_Hooks.md
+++ b/docs/05_技術ノート/ClaudeCode_Hooks.md
@@ -24,6 +24,17 @@ Claude Code のフック機能。特定のイベント発生時にカスタム�
 ```json
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | jq -r '.command' | grep -q 'git commit'; then echo 'コミット前の確認'; fi"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
@@ -31,16 +42,6 @@ Claude Code のフック機能。特定のイベント発生時にカスタム�
           {
             "type": "command",
             "command": "cargo fmt --quiet -- \"$file_path\""
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'セッション終了'"
           }
         ]
       }

--- a/prompts/runs/2026-01-15_06_ドキュメント自動作成の仕組み.md
+++ b/prompts/runs/2026-01-15_06_ドキュメント自動作成の仕組み.md
@@ -31,46 +31,51 @@ CLAUDE.md に以下の作成条件を明記した。
 | 技術ノート | 新ツール導入、技術解説、既存ノートへの追記 |
 | セッションログ | コード変更、設計判断、調査結果 |
 
-### 3. SessionEnd フックの追加
+### 3. リマインドフックの追加
 
-`.claude/settings.json` に SessionEnd フックを追加し、セッション終了時にリマインドを表示するようにした。
+`.claude/settings.json` に PreToolUse フックを追加し、git commit 実行前にリマインドを表示するようにした。
 
 ```json
-"SessionEnd": [
+"PreToolUse": [
   {
+    "matcher": "Bash",
     "hooks": [
       {
         "type": "command",
-        "command": "echo '📝 ドキュメント作成を確認: ADR / 技術ノート / セッションログ（該当する場合）'"
+        "command": "if echo \"$TOOL_INPUT\" | jq -r '.command' | grep -q 'git commit'; then echo '📝 ドキュメント作成を確認'; fi"
       }
     ]
   }
 ]
 ```
 
-**補足**: Stop（毎ターン発火）ではなく SessionEnd（セッション終了時のみ）を採用。
+**経緯**: 当初は SessionEnd（セッション終了時）を採用したが、通常の流れが「作業 → コミット → /exit」であるため、コミット後では遅いことが判明。git commit 検出時に変更した。
 
 ## 成果物
 
 ### コミット
 
 - `69bc6ed` ドキュメント自動作成の仕組みを追加
+- `baf9a91` セッションログと技術ノートを追加
+- `6db345d` ドキュメント作成リマインドをコミット前に変更
 
 ### 更新ファイル
 
 - `CLAUDE.md`: ドキュメント自動作成ルールセクションを追加
-- `.claude/settings.json`: SessionEnd フックを追加
+- `.claude/settings.json`: PreToolUse フックを追加（git commit 検出時）
+- `docs/05_技術ノート/ClaudeCode_Hooks.md`: 新規作成
 
 ## 設計判断と実装解説
 
-### Stop vs SessionEnd の選択
+### リマインドのタイミング選択
 
-| イベント | 発火タイミング | 採用 |
-|---------|--------------|------|
-| Stop | 毎回の応答完了時 | ✗ 頻繁すぎる |
-| SessionEnd | セッション終了時 | ✓ 適切な頻度 |
+| イベント | 発火タイミング | 採用 | 理由 |
+|---------|--------------|------|------|
+| Stop | 毎回の応答完了時 | ✗ | 頻繁すぎる |
+| SessionEnd | セッション終了時 | ✗ | コミット後では遅い |
+| PreToolUse (git commit) | コミット直前 | ✓ | 適切なタイミング |
 
-毎回リマインドが表示されるとうるさいため、SessionEnd を採用した。
+通常のワークフロー（作業 → コミット → /exit）を考慮し、コミット直前にリマインドを表示する方式を採用した。
 
 ## ユーザープロンプト（抜粋）
 
@@ -78,10 +83,15 @@ CLAUDE.md に以下の作成条件を明記した。
 
 > 完全自動化は目指していないのである程度できればいい。
 
+> ドキュメント自動作成について、たいていcommit後に/exitするのでタイミングが合わない。
+
 ## 学んだこと
 
 - Claude Code の Hooks には複数のイベントタイプがあり、用途に応じて使い分ける
   - Stop: 毎ターン終了時
   - SessionEnd: セッション終了時
-  - その他: PreToolUse, PostToolUse, SubagentStop など
+  - PreToolUse: ツール実行前（matcher でツールを絞り込める）
+  - PostToolUse: ツール実行後
+- PreToolUse で `$TOOL_INPUT` を使ってコマンド内容を判定できる
 - セッション中に設定ファイルを変更しても、次回起動まで反映されない
+- リマインドのタイミングはワークフローを考慮して決める必要がある


### PR DESCRIPTION
## Summary

- SessionEnd（セッション終了時）から PreToolUse（git commit 検出時）にリマインドのタイミングを変更
- 通常のワークフロー（作業 → コミット → /exit）を考慮し、コミット直前にリマインドを表示

## Test plan

- [ ] git commit 実行前にリマインドが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)