### PR TITLE
Claude Code Action に permissions を追加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,6 +26,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
 jobs:
   # PRオープン/更新時の自動レビュー
   auto-review:
@@ -42,7 +48,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             このPRをレビューしてください。
             CLAUDE.md に記載されたプロジェクト理念と品質基準に基づいてレビューを行ってください。
@@ -66,6 +72,6 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # コスト制御: 最大10ターンに制限
           claude_args: "--max-turns 10"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,9 +298,19 @@ secrets・`.env`の取り扱い、破壊的コマンドの回避、危険なgit�
 
 ## Git 操作ルール
 
-### PR マージ
+### コミット前
 
-PR をマージする際は `--auto` フラグを使用し、CI が通ってから自動マージする。
+```bash
+just check-all
+```
+
+### Force Push
+
+```bash
+git push --force-with-lease --force-if-includes
+```
+
+### PR マージ
 
 ```bash
 gh pr merge --squash --delete-branch --auto

--- a/docs/03_手順書/02_プロジェクト構築/03_GitHub設定.md
+++ b/docs/03_手順書/02_プロジェクト構築/03_GitHub設定.md
@@ -761,7 +761,6 @@ CLAUDE.md に記載されたプロジェクト理念と品質基準に基づい�
 
 ### 10.1 前提条件
 
-- Anthropic API キーを取得済みであること（https://console.anthropic.com/）
 - リポジトリへの Admin 権限があること
 
 ### 10.2 GitHub App のインストール
@@ -781,27 +780,51 @@ claude
 3. 対象リポジトリを選択（`ka2kama/ringiflow`）
 4. 「Install」で完了
 
-### 10.3 API キーの設定
+### 10.3 認証の設定
 
 ```
 Settings > Secrets and variables > Actions > New repository secret
 ```
 
+**方法 A: OAuth トークン（サブスクリプション利用）**
+
+| 項目 | 値 |
+|------|-----|
+| Name | `CLAUDE_CODE_OAUTH_TOKEN` |
+| Secret | Claude Code CLI で `/install-github-app` 実行時に取得したトークン |
+
+Claude Pro/Max サブスクリプションの利用枠を消費する。
+
+**方法 B: API キー（API 課金）**
+
 | 項目 | 値 |
 |------|-----|
 | Name | `ANTHROPIC_API_KEY` |
-| Secret | Anthropic Console から取得した API キー |
+| Secret | https://console.anthropic.com/ から取得した API キー |
 
-**注意:** API キーは絶対にコードにハードコードしない。
+API 利用料が発生する。利用状況は https://console.anthropic.com/usage で確認。
 
-### 10.4 動作確認
+### 10.4 Ruleset への Status Check 追加
+
+```
+Settings > Rules > Rulesets > main-protection（編集）
+```
+
+「Require status checks to pass」セクションで以下を追加:
+
+| Status Check | 説明 |
+|--------------|------|
+| `CI Success` | CI ワークフローのジョブ |
+| `Auto Review` | Claude Code Review ワークフローのジョブ |
+
+### 10.5 動作確認
 
 1. 新しいブランチを作成し、何らかの変更をコミット
 2. PR を作成
 3. GitHub Actions の「Claude Code Review」ワークフローが実行されることを確認
 4. PR にレビューコメントが投稿されることを確認
 
-### 10.5 使い方
+### 10.6 使い方
 
 | 機能 | 説明 |
 |------|------|
@@ -818,39 +841,40 @@ Settings > Secrets and variables > Actions > New repository secret
 @claude テナント削除時のデータ削除は考慮されていますか？
 ```
 
-### 10.6 コスト管理
+### 10.7 利用制限
 
-Claude Code Action は Anthropic API を使用するため、API 利用料が発生する。
+| 認証方式 | 課金 |
+|---------|------|
+| OAuth トークン | Claude Pro/Max サブスクリプションの利用枠を消費 |
+| API キー | Anthropic API 利用料が発生 |
 
-**コスト削減のポイント:**
+**制限のポイント:**
 
 - ワークフローで `--max-turns` を設定済み（自動レビュー: 5、対話: 10）
 - 不要なワークフロー実行を避ける（ドラフト PR ではスキップ等、必要に応じて設定追加）
 
-**利用状況の確認:**
-
-https://console.anthropic.com/usage
-
-### 10.7 トラブルシューティング
+### 10.8 トラブルシューティング
 
 **ワークフローが実行されない**
 
 1. GitHub App がインストールされているか確認
    - `Settings > GitHub Apps > Installed GitHub Apps`
-2. `ANTHROPIC_API_KEY` が設定されているか確認
+2. 認証情報が設定されているか確認
    - `Settings > Secrets and variables > Actions`
+   - `CLAUDE_CODE_OAUTH_TOKEN` または `ANTHROPIC_API_KEY`
 
 **レビューコメントが投稿されない**
 
 1. ワークフローのログを確認
    - `Actions > Claude Code Review > 該当の実行`
-2. API キーが有効か確認
-   - Anthropic Console でキーのステータスを確認
+2. 認証情報が有効か確認
+   - OAuth: Claude Code CLI で `/install-github-app` を再実行してトークンを再取得
+   - API キー: https://console.anthropic.com/ でキーのステータスを確認
 
-**API エラーが発生する**
+**認証エラーが発生する**
 
-1. API キーの残高・制限を確認
-2. キーが正しく設定されているか再確認（コピペミス等）
+1. Secret が正しく設定されているか再確認（コピペミス等）
+2. GitHub App がリポジトリにインストールされているか確認
 
 ---
 
@@ -858,5 +882,6 @@ https://console.anthropic.com/usage
 
 | 日付 | 変更内容 | 担当 |
 |------|---------|------|
+| 2026-01-15 | Claude Code Action: OAuth トークン方式に変更、Ruleset 設定追加 | - |
 | 2026-01-15 | Claude Code Action 設定手順を追加 | - |
 | 2026-01-14 | 初版作成 | - |

--- a/docs/05_技術ノート/GitHub_Actions_OIDC.md
+++ b/docs/05_技術ノート/GitHub_Actions_OIDC.md
@@ -1,0 +1,40 @@
+# GitHub Actions OIDC 認証
+
+## 概要
+
+OIDC (OpenID Connect) は認証のための標準プロトコル。
+GitHub Actions では、外部サービスへの安全な認証に使用される。
+
+## 仕組み
+
+```text
+GitHub Actions ─── OIDC token ───▶ 外部サービス
+                    │
+                    └─ 「このワークフローは本当に指定リポジトリから実行されている」
+                       という証明（短命トークン）
+```
+
+## API キーとの比較
+
+| 方式 | 仕組み | リスク |
+|------|--------|--------|
+| API キー | Secrets に保存した固定キー | 漏洩時に無期限で悪用可能 |
+| OIDC | 短命のトークンを都度発行 | トークンは数分で失効 |
+
+## GitHub Actions での設定
+
+OIDC を使用するには、ワークフローに `permissions` を設定する:
+
+```yaml
+permissions:
+  id-token: write  # OIDC token の取得に必要
+  contents: read   # リポジトリの読み取り
+```
+
+## RingiFlow での使用箇所
+
+- Claude Code Action: Anthropic API への認証に OIDC を使用
+
+## 参考
+
+- [GitHub Docs: About security hardening with OpenID Connect](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect)

--- a/prompts/runs/2026-01-15_10_BFF_CoreAPI分離.md
+++ b/prompts/runs/2026-01-15_10_BFF_CoreAPI分離.md
@@ -49,6 +49,31 @@ just dev-bff       # BFF 起動（ポート 13000）
 
 - 設計書にライブラリのバージョンを書くと乖離リスクがある
 - 設計書は「構造・意図・考え方」に集中し、詳細は実装に任せるべき
+- コミット前に lint と test を実行すべき
+
+## 副次的な修正: Claude Code Action
+
+PR 作成時に Claude Code Review ワークフローが OIDC token エラーで失敗。
+調査の結果、以下が漏れていたことが判明:
+
+1. ワークフローの `permissions` 設定（`id-token: write` が必要）
+2. ruleset への required status checks 追加手順
+
+### 修正内容
+
+`.github/workflows/claude-review.yml` に permissions を追加:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+```
+
+### 関連
+
+- 技術ノート: [GitHub Actions OIDC](../../docs/05_技術ノート/GitHub_Actions_OIDC.md)
 
 ## 次のステップ
 


### PR DESCRIPTION
## Summary

- OIDC token 取得エラーを修正
- `id-token: write` 権限が不足していた

## Test plan

- [ ] Claude Code Review ワークフローが成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)