### PR TITLE
Claude Code Action の権限設定を修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,6 +30,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  actions: read
   id-token: write
 
 jobs:
@@ -52,8 +53,12 @@ jobs:
           prompt: |
             このPRをレビューしてください。
             CLAUDE.md に記載されたプロジェクト理念と品質基準に基づいてレビューを行ってください。
-          # コスト制御: 最大5ターンに制限
-          claude_args: "--max-turns 5"
+          # 許可ツール:
+          #   読み取り: gh pr view/list/diff/checks, git log/diff/show/status
+          #   書き込み: gh pr comment/review, インラインコメント
+          claude_args: |
+            --max-turns 20
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"
 
   # @claude メンションへの応答
   interactive-review:
@@ -73,5 +78,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # コスト制御: 最大10ターンに制限
-          claude_args: "--max-turns 10"
+          # 許可ツール:
+          #   読み取り: gh pr view/list/diff/checks, git log/diff/show/status
+          #   書き込み: gh pr comment/review, インラインコメント
+          claude_args: |
+            --max-turns 20
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"

--- a/docs/05_技術ノート/ClaudeCodeAction_権限設定.md
+++ b/docs/05_技術ノート/ClaudeCodeAction_権限設定.md
@@ -1,0 +1,141 @@
+# Claude Code Action 権限設定
+
+Claude Code Action を GitHub Actions で使用する際の権限設定についてまとめる。
+
+## セキュリティモデル
+
+Claude Code Action は**セキュリティ上の理由から Bash ツールをデフォルトで無効化**している。
+
+- ファイル操作やコメント管理はデフォルトで使用可能
+- Bash コマンド（`gh`, `git` など）は明示的な許可が必要
+- `.claude/settings.json` の設定は CI 環境では効かない
+- ワークフローファイルの `claude_args` で `--allowedTools` を指定する必要がある
+
+## 基本設定
+
+### GitHub トークン権限
+
+```yaml
+permissions:
+  contents: read       # リポジトリ読み取り
+  pull-requests: write # PR へのコメント
+  issues: write        # Issue へのコメント
+  actions: read        # CI 結果の確認（オプション）
+  id-token: write      # OIDC 認証（OAuth 使用時に必要）
+```
+
+### ツール許可の構文
+
+```yaml
+claude_args: |
+  --max-turns 20
+  --allowedTools "Bash(gh pr view:*),Bash(git log:*)"
+```
+
+**形式**:
+- `Bash(command:*)`: 特定コマンドのすべてのサブコマンド・引数を許可
+- `Bash(command subcommand:*)`: より限定的な許可
+- `mcp__server__tool`: MCP サーバーのツール
+
+## PR レビュー用の推奨設定
+
+### 読み取り操作
+
+```
+Bash(gh pr view:*)     # PR 詳細
+Bash(gh pr list:*)     # PR 一覧
+Bash(gh pr diff:*)     # PR 差分
+Bash(gh pr checks:*)   # CI 状態
+Bash(git log:*)        # コミット履歴
+Bash(git diff:*)       # 差分
+Bash(git show:*)       # コミット内容
+Bash(git status:*)     # 状態
+```
+
+### 書き込み操作
+
+```
+Bash(gh pr comment:*)  # PR コメント
+Bash(gh pr review:*)   # PR レビュー
+mcp__github_inline_comment__create_inline_comment  # インラインコメント
+```
+
+### 完全な設定例
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    prompt: |
+      この PR をレビューしてください。
+    claude_args: |
+      --max-turns 20
+      --allowedTools "Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"
+```
+
+## 注意事項
+
+### 広範な権限は避ける
+
+```yaml
+# NG: 危険なコマンドも含まれる
+--allowedTools "Bash(gh:*)"   # gh repo delete 等も許可される
+--allowedTools "Bash(git:*)"  # git push --force 等も許可される
+
+# OK: 必要な操作のみ許可
+--allowedTools "Bash(gh pr view:*),Bash(gh pr list:*)"
+```
+
+### max-turns の設定
+
+PR レビューには複数ステップが必要：
+1. PR 情報取得
+2. 差分確認
+3. コード読み込み
+4. 分析
+5. コメント投稿
+
+5 ターンでは不足する場合が多い。20 ターン程度を推奨。
+
+### MCP ツールの許可
+
+MCP サーバーのツールは `mcp__<server>__<tool>` 形式で指定：
+
+```yaml
+--allowedTools "mcp__github_inline_comment__create_inline_comment"
+```
+
+## トラブルシューティング
+
+### permission_denials エラー
+
+```json
+{
+  "permission_denials": [{
+    "tool_name": "Bash",
+    "tool_input": { "command": "gh pr list" }
+  }]
+}
+```
+
+**原因**: `--allowedTools` で許可されていないコマンドを実行しようとした
+
+**解決**: 必要なコマンドを `--allowedTools` に追加
+
+### error_max_turns エラー
+
+```json
+{
+  "subtype": "error_max_turns",
+  "num_turns": 5
+}
+```
+
+**原因**: 設定されたターン数内で処理が完了しなかった
+
+**解決**: `--max-turns` を増やす
+
+## 参考リンク
+
+- [Claude Code Action リポジトリ](https://github.com/anthropics/claude-code-action)
+- [Claude Code GitHub Actions ドキュメント](https://code.claude.com/docs/en/github-actions)

--- a/prompts/runs/2026-01-16_01_ClaudeCodeAction権限修正.md
+++ b/prompts/runs/2026-01-16_01_ClaudeCodeAction権限修正.md
@@ -1,0 +1,92 @@
+# 2026-01-16_01: Claude Code Action 権限修正
+
+## 概要
+
+PR #25 の Claude Code Action による自動レビューが失敗していた問題を調査し、権限設定を修正した。
+
+## 背景と目的
+
+PR #25 の CI で「Auto Review」ジョブが失敗していた。原因は Claude Code Action が `gh pr list` コマンドを実行しようとした際に、Bash ツールの権限がなく拒否されたこと。
+
+## 実施内容
+
+### 1. 問題の調査
+
+GitHub Actions のログを確認し、以下の原因を特定：
+
+```json
+{
+  "type": "result",
+  "subtype": "error_max_turns",
+  "permission_denials": [
+    {
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "gh pr list --state open --limit 5"
+      }
+    }
+  ]
+}
+```
+
+- Claude Code Action は**セキュリティ上の理由から Bash ツールをデフォルトで無効化**している
+- `gh` コマンドを使うには `--allowedTools` で明示的に許可が必要
+- `max-turns: 5` では PR レビューに必要なステップを完了できない
+
+### 2. 解決策の検討
+
+最新の Claude Code Action ドキュメントを調査し、以下を確認：
+
+- `claude_args` の `--allowedTools` フラグで特定のツールを許可可能
+- 形式: `Bash(command:*)` でコマンドパターンを指定
+- `Bash(gh:*)` のような広範な許可は危険（`gh repo delete` 等も含まれる）
+
+### 3. 権限設定の修正
+
+`.github/workflows/claude-review.yml` を以下のように修正：
+
+**permissions**:
+- `actions: read` を追加（CI 結果確認用）
+
+**claude_args**:
+- `--max-turns 20` に増加
+- `--allowedTools` で必要最小限のコマンドのみ許可：
+  - 読み取り: `gh pr view/list/diff/checks`, `git log/diff/show/status`
+  - 書き込み: `gh pr comment/review`, `mcp__github_inline_comment__create_inline_comment`
+
+## 成果物
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `.github/workflows/claude-review.yml` | 権限設定とツール許可を追加 |
+| `prompts/runs/2026-01-16_01_ClaudeCodeAction権限修正.md` | セッションログ |
+| `docs/05_技術ノート/ClaudeCodeAction_権限設定.md` | 技術ノート |
+
+## ユーザープロンプト（抜粋）
+
+> claude-review.yml 側の権限ではありませんか？
+
+> `claude_args` の `allowedTools` ではありませんか？
+
+> そのような広範な権限を付与して大丈夫ですか？
+
+> レビュー結果をコメントする権限は必要ではありませんか？
+
+> `mcp__github_inline_comment__create_inline_comment` もあると良さそうです。
+
+> `max-turns` が少なすぎませんか？
+
+## 学んだこと
+
+1. **Claude Code Action のセキュリティモデル**: Bash ツールはデフォルトで無効。CI 環境では `.claude/settings.json` の設定だけでは不十分で、`claude_args` での明示的許可が必要
+
+2. **最小権限の原則**: `Bash(gh:*)` のような広範な許可は危険。レビュー用途では読み取り操作と必要な書き込み操作のみに限定すべき
+
+3. **適切なターン数**: PR レビューには複数ステップ（PR 確認 → コード読み → 分析 → コメント投稿）が必要。5 ターンでは不足、20 ターン程度が妥当
+
+## 次のステップ
+
+- この変更をコミットし、PR #25 に適用
+- レビューが正常に動作することを確認


### PR DESCRIPTION
## Summary

- Auto Review で `gh pr list` コマンドが拒否されていた問題を修正
- `permissions` に `actions: read` を追加
- `--allowedTools` で読み取り/書き込み操作を限定許可
- `max-turns` を 20 に増加

## Test plan

- [ ] PR #25 にマージ後、Auto Review が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)