### PR TITLE
Auto Review がキャンセルされる問題を修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,8 +22,9 @@ on:
     types: [created]
 
 # 同時実行制御: 同一PRでの重複実行を防止
+# イベントタイプも含めることで、auto-review と interactive-review が互いをキャンセルしない
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

- concurrency group にイベントタイプを含めることで、auto-review と interactive-review が互いをキャンセルしないようにした

## 原因

Auto Review のコメント投稿が `issue_comment` イベントをトリガーし、同じ concurrency グループで新しいワークフローが開始され、実行中の Auto Review がキャンセルされていた。

## 修正内容

```yaml
# Before
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}

# After
group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number }}
```

## Test plan

- [ ] PR で Auto Review が最後まで実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)