### PR TITLE
Auto Review の max-turns を 20 から 40 に増加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -108,7 +108,7 @@ jobs:
           #   読み取り: gh pr view/list/diff/checks, git log/diff/show/status
           #   書き込み: gh pr comment/review, インラインコメント
           claude_args: |
-            --max-turns 20
+            --max-turns 40
             --allowedTools "Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"
 
   # @claude メンションへの応答
@@ -133,5 +133,5 @@ jobs:
           #   読み取り: gh pr view/list/diff/checks, git log/diff/show/status
           #   書き込み: gh pr comment/review, インラインコメント
           claude_args: |
-            --max-turns 20
+            --max-turns 40
             --allowedTools "Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Summary
- Auto Review の max-turns を 20 から 40 に増加
- 大規模な PR（32ファイル変更等）で max-turns に達してレビューが完了しない問題に対応

## Test plan
- [ ] PR #28 で Auto Review が完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)