### PR TITLE
依存関係ルールを追加し rstest を更新

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "frontend/**"
+  - "**/elm.json"
+  - "**/package.json"
+---
+
+# フロントエンド実装ルール
+
+このルールはフロントエンド（`frontend/`）のファイルを編集する際に適用される。
+
+## 依存関係
+
+依存関係を追加する際は、最新の stable バージョンを使用する。
+
+### npm パッケージ
+
+```bash
+# pnpm で追加（自動的に最新バージョン）
+pnpm add <package>
+pnpm add -D <package>  # devDependencies
+
+# または npm view で確認して手動追加
+npm view <package> version
+```
+
+### Elm パッケージ
+
+```bash
+# elm install で追加
+elm install <author/package>
+```
+
+## AI エージェントへの指示
+
+1. 依存関係を追加する際は最新の stable バージョンを使用する
+2. `pnpm add` または `elm install` で追加
+3. 更新後は `pnpm install` でロックファイルを同期

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -48,7 +48,7 @@ dotenvy = "0.15"
 # テスト
 tokio-test = "0.4"
 pretty_assertions = "1.4"
-rstest = "0.23"
+rstest = "0.26"
 
 # 内部クレート
 ringiflow-domain = { path = "crates/domain" }


### PR DESCRIPTION
## 概要

依存関係追加時のルールを整備し、rstest を更新。

## 変更内容

### ルール追加
- `.claude/rules/frontend.md`: フロントエンドの依存関係ルール
  - pnpm/elm で最新 stable を使用

### 依存関係更新
- rstest: 0.23 → 0.26

🤖 Generated with [Claude Code](https://claude.ai/code)