### PR TITLE
PostToolUse hook を修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,7 +109,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); if [[ \"$file_path\" == *.rs ]]; then cargo fmt --quiet -- \"$file_path\" 2>/dev/null || true; fi"
+            "command": "file_path=$(echo \"$TOOL_INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [[ \"$file_path\" == *.rs ]]; then just fmt-rust \"$file_path\" 2>/dev/null || true; elif [[ \"$file_path\" == *.elm ]]; then just fmt-elm \"$file_path\" 2>/dev/null || true; fi"
           }
         ]
       }

--- a/docs/06_技術ノート/ClaudeCode_Hooks.md
+++ b/docs/06_技術ノート/ClaudeCode_Hooks.md
@@ -99,8 +99,103 @@ PreToolUse / PostToolUse で特定のツールにのみフックを適用する�
 
 正規表現パターンでツール名をマッチさせる。
 
+## 環境変数
+
+フック内で利用できる環境変数:
+
+| 変数 | 内容 |
+|------|------|
+| `$TOOL_INPUT` | ツールに渡された入力（JSON 形式） |
+| `$TOOL_OUTPUT` | ツールの出力（PostToolUse のみ） |
+
+### $TOOL_INPUT の例
+
+**Write ツールの場合:**
+```json
+{
+  "file_path": "/path/to/file.rs",
+  "content": "fn main() { ... }"
+}
+```
+
+**Bash ツールの場合:**
+```json
+{
+  "command": "git commit -m \"message\""
+}
+```
+
+### jq でのパース例
+
+```bash
+# file_path を取得
+file_path=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty')
+
+# command を取得
+command=$(echo "$TOOL_INPUT" | jq -r '.command // empty')
+```
+
+## プロジェクト設定例
+
+### Rust/Elm ファイルの自動フォーマット（PostToolUse）
+
+`.rs` / `.elm` ファイルを Write/Edit した後に自動でフォーマットする。
+
+```json
+{
+  "PostToolUse": [
+    {
+      "matcher": "Write|Edit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "file_path=$(echo \"$TOOL_INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [[ \"$file_path\" == *.rs ]]; then just fmt-rust \"$file_path\" 2>/dev/null || true; elif [[ \"$file_path\" == *.elm ]]; then just fmt-elm \"$file_path\" 2>/dev/null || true; fi"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**コマンドの解説:**
+1. `echo "$TOOL_INPUT" | jq -r '.file_path // empty'` - JSON から `file_path` を取得
+2. `2>/dev/null` - jq のエラーを抑制
+3. `[[ "$file_path" == *.rs ]]` - `.rs` ファイルなら `just fmt-rust`
+4. `[[ "$file_path" == *.elm ]]` - `.elm` ファイルなら `just fmt-elm`
+5. `|| true` - フォーマット失敗時もエラーにしない
+
+**ポイント:** フォーマット設定を justfile に集約することで、手動実行時と hook 実行時で同じ設定が使われる。
+
+### コミット前の lint 実行（PreToolUse）
+
+`git commit` 前にステージされたファイルに応じて lint/test を実行する。
+
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "if echo \"$TOOL_INPUT\" | jq -r '.command // empty' 2>/dev/null | grep -q 'git commit'; then ./.claude/hooks/pre-commit-check.sh || exit 1; fi"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**コマンドの解説:**
+1. `jq -r '.command // empty'` - Bash ツールの `command` を取得
+2. `grep -q 'git commit'` - `git commit` が含まれているか確認
+3. `./.claude/hooks/pre-commit-check.sh` - 外部スクリプトを実行
+4. `|| exit 1` - スクリプトが失敗したら hook を失敗させる
+
 ## 注意点
 
 - セッション中に設定を変更しても、次回起動まで反映されない
 - Stop はユーザーが `Ctrl+C` で中断した場合は発火しない
 - SessionEnd は `/exit` や `Ctrl+D` での正常終了時に発火する
+- PostToolUse の hook はツール実行後に同期的に実行される
+- hook が失敗しても（`|| true` がなければ）ツール実行自体は成功扱いになる

--- a/justfile
+++ b/justfile
@@ -85,13 +85,23 @@ dev-web:
 # 全体フォーマット
 fmt: fmt-rust fmt-elm
 
-# Rust フォーマット
-fmt-rust:
-    cd backend && cargo +nightly fmt --all
+# Rust フォーマット（引数なし=全ファイル、引数あり=指定ファイル）
+fmt-rust *files:
+    #!/usr/bin/env bash
+    if [ -z "{{files}}" ]; then
+        cd backend && cargo +nightly fmt --all
+    else
+        rustfmt +nightly --edition 2024 --quiet {{files}}
+    fi
 
-# Elm フォーマット
-fmt-elm:
-    cd frontend && pnpm run fmt
+# Elm フォーマット（引数なし=全ファイル、引数あり=指定ファイル）
+fmt-elm *files:
+    #!/usr/bin/env bash
+    if [ -z "{{files}}" ]; then
+        cd frontend && pnpm run fmt
+    else
+        elm-format --yes {{files}}
+    fi
 
 # =============================================================================
 # リント（フォーマットチェック含む）

--- a/prompts/runs/2026-01-17_05_PostToolUseHook修正.md
+++ b/prompts/runs/2026-01-17_05_PostToolUseHook修正.md
@@ -1,0 +1,103 @@
+# 2026-01-17_05_PostToolUseHook修正
+
+## 概要
+
+Claude Code の PostToolUse hook が動作していなかった問題を修正。
+
+## 背景と目的
+
+PR #46 の CI で Rust ファイルのフォーマットエラーが発生。
+調査の結果、`.rs` ファイル作成後の自動フォーマット hook が動作していなかった。
+
+## 実施内容
+
+### 1. 問題の特定
+
+PostToolUse hook のコマンドを調査:
+
+```bash
+# 修正前（動作しない）
+file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+```
+
+**問題点:**
+1. `jq` に入力（`$TOOL_INPUT`）を渡していない
+2. JSON のキーが `.tool_input.file_path` ではなく `.file_path`
+
+### 2. 追加の問題
+
+`cargo fmt` を使用していたが、`Cargo.toml` がカレントディレクトリにない場合に失敗する。
+
+```bash
+# エラー
+error: could not find `Cargo.toml` in `/path/to/project` or any parent directory
+```
+
+### 3. 修正
+
+```bash
+# 修正後
+file_path=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty' 2>/dev/null)
+if [[ "$file_path" == *.rs ]]; then
+    just fmt-rust "$file_path" 2>/dev/null || true
+elif [[ "$file_path" == *.elm ]]; then
+    just fmt-elm "$file_path" 2>/dev/null || true
+fi
+```
+
+**修正点:**
+1. `echo "$TOOL_INPUT" |` で jq に入力を渡す
+2. `.file_path` で直接キーを参照
+3. `just fmt-rust` / `just fmt-elm` を使用（設定を justfile に集約）
+
+### 4. justfile の改善
+
+`fmt-rust` をオプショナル引数対応にして、設定を一箇所に集約:
+
+```just
+# Rust フォーマット（引数なし=全ファイル、引数あり=指定ファイル）
+fmt-rust *files:
+    #!/usr/bin/env bash
+    if [ -z "{{files}}" ]; then
+        cd backend && cargo +nightly fmt --all
+    else
+        rustfmt +nightly --edition 2024 --quiet {{files}}
+    fi
+```
+
+## 成果物
+
+### 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `.claude/settings.json` | PostToolUse hook を修正 |
+| `justfile` | `fmt-rust` をオプショナル引数対応に改善 |
+| `docs/06_技術ノート/ClaudeCode_Hooks.md` | 環境変数とプロジェクト設定例を追加 |
+
+## 学んだこと
+
+### Claude Code hook のデバッグ
+
+1. hook のコマンドは手動で実行してテストできる:
+   ```bash
+   TOOL_INPUT='{"file_path":"test.rs"}' bash -c 'hook_command_here'
+   ```
+
+2. `$TOOL_INPUT` は JSON 形式で、ツールの引数がそのまま入る
+
+3. `cargo fmt` は `Cargo.toml` が必要なので、`rustfmt` を直接使う方が汎用的
+
+### hook が動作しない場合のチェックポイント
+
+1. `$TOOL_INPUT` を正しくパイプしているか
+2. JSON のキー名が正しいか
+3. コマンドがカレントディレクトリに依存していないか
+
+詳細: [ClaudeCode_Hooks 技術ノート](../../docs/06_技術ノート/ClaudeCode_Hooks.md)
+
+## ユーザープロンプト（抜粋）
+
+> commit 時に lint してフォーマットも含めチェックしているはずだが hook が動いていないのか間違っているのか
+
+> hook のコマンドが複雑なので技術ノートかコメントで補足してください。あとセッションログもお願いします。


### PR DESCRIPTION
## Summary

- PostToolUse hook が動作しない問題を修正
- `$TOOL_INPUT` を jq に正しくパイプするよう修正
- Rust/Elm ファイルの自動フォーマットに対応
- フォーマット設定を justfile に集約（sync 漏れ防止）

## Test plan

- [x] `just fmt-rust /path/to/file.rs` が単一ファイルをフォーマット
- [x] `just fmt-elm /path/to/file.elm` が単一ファイルをフォーマット
- [x] hook コマンドを手動テストして動作確認
- [ ] 新規セッションで `.rs` / `.elm` ファイル編集後に自動フォーマットされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)