### PR TITLE
マージ後のローカルブランチ削除手順を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,6 +508,12 @@ git push --force-with-lease --force-if-includes
 gh pr merge --squash --delete-branch --auto
 ```
 
+**マージ後のローカルブランチ削除:**
+
+```bash
+just clean-branches
+```
+
 **禁止事項:**
 - `--admin` フラグで CI をバイパスしない
 - CI が失敗している状態で強制マージしない

--- a/docs/04_手順書/04_開発フロー/01_Issue駆動開発.md
+++ b/docs/04_手順書/04_開発フロー/01_Issue駆動開発.md
@@ -257,6 +257,12 @@ gh pr merge --squash --delete-branch
 
 **注意:** `--auto` は使用しない。レビュー結果を確認してからマージすること。
 
+**マージ後のローカルブランチ削除:**
+
+```bash
+just clean-branches
+```
+
 ## Milestone
 
 Phase ごとに Milestone を作成している。Issue 作成時に適切な Milestone を設定する。
@@ -342,6 +348,7 @@ gh api repos/ka2kama/ringiflow/milestones
 
 | 日付 | 変更内容 |
 |------|---------|
+| 2026-01-17 | マージ後のローカルブランチ削除手順を追加 |
 | 2026-01-17 | lefthook による Issue 番号の自動付与を追加 |
 | 2026-01-17 | コミットメッセージ・PR タイトルの先頭に Issue 番号を含める形式に統一 |
 | 2026-01-17 | Issue の進捗更新ルールを追加 |

--- a/justfile
+++ b/justfile
@@ -157,3 +157,10 @@ clean:
     docker compose -f infra/docker/docker-compose.yml down -v
     cd backend && cargo clean
     cd frontend && rm -rf node_modules elm-stuff dist
+
+# マージ済みローカルブランチを削除
+clean-branches:
+    git switch main
+    git pull
+    git fetch --prune
+    git branch --merged main | grep -v main | xargs -r git branch -d


### PR DESCRIPTION
## Summary
- `just clean-branches` タスクを追加
- CLAUDE.md と手順書にマージ後のローカルブランチ削除手順を追記

## Test plan
- [ ] `just clean-branches` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)