### PR TITLE
Claude Code hooks を stdin 入力方式に統一し外部スクリプト化

### DIFF
--- a/.claude/hooks/post-write-format.sh
+++ b/.claude/hooks/post-write-format.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PostToolUse hook: Write/Edit 後にフォーマッタを実行
+set -euo pipefail
+
+LOG_FILE="/tmp/claude/post-write-format.log"
+mkdir -p /tmp/claude
+
+# stdin から file_path を抽出
+file_path=$(cat | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+[[ -z "$file_path" ]] && exit 0
+
+case "$file_path" in
+    *.rs)
+        just fmt-rust "$file_path" >> "$LOG_FILE" 2>&1 \
+            && echo "[$(date '+%H:%M:%S')] fmt-rust: $file_path" >> "$LOG_FILE"
+        ;;
+    *.elm)
+        just fmt-elm "$file_path" >> "$LOG_FILE" 2>&1 \
+            && echo "[$(date '+%H:%M:%S')] fmt-elm: $file_path" >> "$LOG_FILE"
+        ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | jq -r '.command // empty' 2>/dev/null | grep -q 'git commit'; then ./.claude/hooks/pre-commit-check.sh || exit 1; echo '📝 ドキュメント作成を確認: ADR / 技術ノート / セッションログ（該当する場合）'; fi"
+            "command": "input=$(cat); if echo \"$input\" | jq -r '.tool_input.command // empty' 2>/dev/null | grep -q 'git commit'; then ./.claude/hooks/pre-commit-check.sh || exit 1; echo '📝 ドキュメント作成を確認: ADR / 技術ノート / セッションログ（該当する場合）'; fi"
           }
         ]
       }
@@ -109,7 +109,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file_path=$(echo \"$TOOL_INPUT\" | jq -r '.file_path // empty' 2>/dev/null); if [[ \"$file_path\" == *.rs ]]; then just fmt-rust \"$file_path\" 2>/dev/null || true; elif [[ \"$file_path\" == *.elm ]]; then just fmt-elm \"$file_path\" 2>/dev/null || true; fi"
+            "command": "./.claude/hooks/post-write-format.sh"
           }
         ]
       }
@@ -128,7 +128,8 @@
       "docker",
       "docker-compose",
       "psql",
-      "redis-cli"
+      "redis-cli",
+      "just"
     ]
   },
   "attribution": {

--- a/prompts/runs/2026-01/2026-01-17_13_PostToolUse_hooks改善.md
+++ b/prompts/runs/2026-01/2026-01-17_13_PostToolUse_hooks改善.md
@@ -1,0 +1,60 @@
+# 2026-01-17_13 PostToolUse hooks 改善
+
+## 概要
+
+Claude Code の PostToolUse hooks が動作しない問題を調査・解決し、stdin 入力方式への統一と外部スクリプト化を実施した。
+
+## 変更内容
+
+### 新規作成
+
+- `.claude/hooks/post-write-format.sh` - PostToolUse hook スクリプト
+
+### 変更
+
+- `.claude/settings.json`
+  - PreToolUse: `$TOOL_INPUT` 環境変数 → stdin 入力方式（`.tool_input.*`）
+  - PostToolUse: インラインコマンド → 外部スクリプト参照
+  - sandbox.excludedCommands に `just` を追加
+- `docs/06_技術ノート/ClaudeCode_Hooks.md` - stdin 入力方式の解説を追加
+
+## 調査結果
+
+### 問題
+
+PostToolUse hooks が Claude Code から呼ばれていなかった。
+
+### 原因
+
+jq でのパス指定が誤っていた。
+
+- 誤: `.file_path`（トップレベルの file_path を参照）
+- 正: `.tool_input.file_path`（tool_input 内の file_path を参照）
+
+stdin から受け取る JSON は以下の構造:
+
+```json
+{
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/path/to/file.rs",
+    ...
+  }
+}
+```
+
+### 解決
+
+jq のパスを `.tool_input.*` 形式に修正したところ、hooks が正常に動作することを確認。
+
+## 学んだこと
+
+1. hooks の stdin JSON は `tool_input` でラップされている
+2. hooks の stdout は通常表示されない（verbose モードでのみ表示）
+3. デバッグにはログファイル出力が有効
+4. 複雑な hook は外部スクリプト化することで可読性とデバッグ性が向上
+
+## 関連
+
+- PR: #67
+- 技術ノート: [ClaudeCode_Hooks.md](../../docs/06_技術ノート/ClaudeCode_Hooks.md)


### PR DESCRIPTION
## Summary

- PreToolUse hook を `$TOOL_INPUT` 環境変数から stdin 入力方式（`.tool_input.*`）に修正
- PostToolUse hook をインラインコマンドから外部スクリプト（`post-write-format.sh`）に変更
- Write/Edit 後に rustfmt/elm-format を自動実行するフォーマッタ hook を追加
- sandbox.excludedCommands に `just` を追加

## Test plan

- [x] PostToolUse hook が Edit 後に自動実行されることを確認済み
- [x] rustfmt が正しく適用されることを確認済み
- [x] ログファイル（`/tmp/claude/post-write-format.log`）に実行記録が出力されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)