### PR TITLE
CI に Rust 統合テストジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,81 @@ jobs:
       - name: Lint
         run: just lint-rust
 
-      - name: Test
-        run: cargo test --release --all-features
+      - name: Test (unit tests)
+        # 統合テスト（tests/）は rust-integration ジョブで実行
+        run: cargo test --release --all-features --lib --bins
+        working-directory: backend
+
+  # Rust 統合テスト: PostgreSQL / Redis を使用するテスト
+  rust-integration:
+    name: Rust Integration
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+
+    services:
+      postgres:
+        image: postgres:17
+        ports:
+          - 15432:5432
+        env:
+          POSTGRES_USER: ringiflow
+          POSTGRES_PASSWORD: ringiflow
+          POSTGRES_DB: ringiflow_test
+        options: >-
+          --health-cmd "pg_isready -U ringiflow"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7
+        ports:
+          - 16379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      SQLX_OFFLINE: true
+      DATABASE_URL: postgres://ringiflow:ringiflow@localhost:15432/ringiflow_test
+      REDIS_URL: redis://localhost:16379
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            backend/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install sqlx-cli
+        run: cargo install sqlx-cli --no-default-features --features rustls,postgres
+
+      - name: Run migrations
+        run: sqlx migrate run
+        working-directory: backend
+
+      - name: Test (integration tests)
+        run: cargo test --release --all-features --test '*'
         working-directory: backend
 
   # Elm チェック: リント、テスト、ビルド
@@ -164,7 +237,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [changes, rust, elm, shell]
+    needs: [changes, rust, rust-integration, elm, shell]
     if: always()
     steps:
       - name: Check results
@@ -176,6 +249,11 @@ jobs:
 
           if [[ "${{ needs.rust.result }}" == "failure" ]]; then
             echo "Rust checks failed"
+            exit 1
+          fi
+
+          if [[ "${{ needs.rust-integration.result }}" == "failure" ]]; then
+            echo "Rust integration tests failed"
             exit 1
           fi
 

--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,6 +1,6 @@
 # Claude Code Action 自動レビュー
 #
-# PRオープン/更新時に自動でコードレビューを実行する。
+# CI 完了後に自動でコードレビューを実行する。
 # Draft PR は除外。
 #
 # 設計判断: [ADR-011](../../docs/05_ADR/011_Claude_Code_Action導入.md)
@@ -8,12 +8,14 @@
 name: Claude Auto Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 # 同時実行制御: 同一PRでの重複実行を防止
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -27,22 +29,38 @@ jobs:
   auto-review:
     name: Auto Review
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    # PR 起因かつ CI 成功の場合のみ実行（Draft チェックはステップ内で実施）
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0] != null
 
     steps:
+      - name: Check if PR is draft
+        id: check-draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}
+          IS_DRAFT=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')
+          echo "is_draft=$IS_DRAFT" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
+        if: steps.check-draft.outputs.is_draft == 'false'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Run Claude Code Review
+        if: steps.check-draft.outputs.is_draft == 'false'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
 
             ## 基本方針
 

--- a/prompts/runs/2026-01/2026-01-18_06_CI統合テストとレビュー実行順序.md
+++ b/prompts/runs/2026-01/2026-01-18_06_CI統合テストとレビュー実行順序.md
@@ -1,0 +1,73 @@
+# CI 統合テストジョブ追加と Claude Auto Review 実行順序変更
+
+## 概要
+
+CI に Rust 統合テストジョブを追加し、Claude Auto Review を CI 完了後に実行するよう変更した。
+
+## 背景と目的
+
+Phase 6 で追加した統合テスト（PostgreSQL / Redis 使用）が CI で実行できていなかった。また、Claude Auto Review が CI チェックと並行して実行されていたため、CI 失敗時にも無駄にレビューが走っていた。
+
+## 実施内容
+
+### 1. CI に rust-integration ジョブを追加
+
+PostgreSQL と Redis を使用する統合テストを実行するジョブを追加:
+
+```yaml
+rust-integration:
+  services:
+    postgres:
+      image: postgres:17
+    redis:
+      image: redis:7
+  steps:
+    - Install sqlx-cli
+    - Run migrations
+    - Test (integration tests)
+```
+
+### 2. Claude Auto Review を CI 完了後に実行
+
+`pull_request` トリガーから `workflow_run` トリガーに変更:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+```
+
+追加の変更:
+- CI 成功時のみ実行（`conclusion == 'success'`）
+- Draft PR のチェックを `gh pr view` で実施（`workflow_run` では Draft 情報が取得できないため）
+
+## 成果物
+
+### PR
+
+- [#68 CI に Rust 統合テストジョブを追加](https://github.com/ka2kama/ringiflow/pull/68)
+
+### 更新したファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `.github/workflows/ci.yml` | rust-integration ジョブ追加 |
+| `.github/workflows/claude-auto-review.yml` | CI 完了後実行、Draft チェック追加 |
+
+## 設計判断と実装解説
+
+### workflow_run トリガーの制約
+
+`workflow_run` イベントでは `pull_requests` 配列にベーシックな情報（number, head, base）しか含まれず、`draft` フラグは含まれない。そのため、Draft PR の除外は追加のステップで `gh pr view` を使って確認する必要がある。
+
+### CI 失敗時の挙動
+
+`conclusion == 'success'` を条件にしているため、CI が失敗した場合は Auto Review はスキップされる。これにより、無駄なレビュー実行を防ぐ。
+
+## 学んだこと
+
+- `workflow_run` トリガーでは元の PR のコンテキストが限定的
+- `github.event.workflow_run.pull_requests` には Draft 情報が含まれない
+- Draft チェックは `gh pr view` で API 呼び出しが必要


### PR DESCRIPTION
## Summary
- rust-integration ジョブを追加（PostgreSQL + Redis を使用）
- マイグレーション実行ステップを追加
- rust ジョブは単体テストのみに変更（`--lib --bins`）

## Test plan
- [ ] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)