### PR TITLE
Claude Auto Review: workflow_run での track_progress を無効化

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -57,7 +57,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
+          # workflow_run イベントでは track_progress はサポートされていない
+          track_progress: false
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary
- `workflow_run` イベントでは `track_progress` がサポートされていないため `false` に変更
- 対応イベント: `pull_request`, `issues`, `issue_comment`, `pull_request_review_comment`, `pull_request_review`

## Test plan
- [ ] CI が通ること
- [ ] workflow_run で起動した Claude Auto Review が正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)