### PR TITLE
#70 Auto Review: GitHub Status API でステータスを報告

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -4,6 +4,9 @@
 # Draft PR は除外。
 #
 # 設計判断: [ADR-011](../../docs/05_ADR/011_Claude_Code_Action導入.md)
+#
+# 注意: workflow_run イベントは PR のステータスチェックに自動で紐付かないため、
+# GitHub Status API を使って明示的にステータスを報告している。
 
 name: Claude Auto Review
 
@@ -23,6 +26,7 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
+  statuses: write # Status API でステータスを報告するために必要
   id-token: write
 
 jobs:
@@ -35,7 +39,22 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.pull_requests[0] != null
 
+    env:
+      STATUS_URL: repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
     steps:
+      - name: Report pending status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # ステータス報告は補助機能のため、失敗してもワークフローを継続
+        run: |
+          gh api "$STATUS_URL" \
+            -f state=pending \
+            -f context="Claude Auto Review" \
+            -f description="Running auto review..." \
+            -f target_url="$RUN_URL" || true
+
       - name: Check if PR is draft
         id: check-draft
         env:
@@ -45,6 +64,17 @@ jobs:
           IS_DRAFT=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')
           echo "is_draft=$IS_DRAFT" >> "$GITHUB_OUTPUT"
 
+      - name: Report skipped status for draft PR
+        if: steps.check-draft.outputs.is_draft == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "$STATUS_URL" \
+            -f state=success \
+            -f context="Claude Auto Review" \
+            -f description="Skipped (draft PR)" \
+            -f target_url="$RUN_URL" || true
+
       - name: Checkout
         if: steps.check-draft.outputs.is_draft == 'false'
         uses: actions/checkout@v6
@@ -53,6 +83,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Run Claude Code Review
+        id: review
         if: steps.check-draft.outputs.is_draft == 'false'
         uses: anthropics/claude-code-action@v1
         with:
@@ -139,3 +170,25 @@ jobs:
           claude_args: |
             --max-turns 40
             --allowedTools "Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"
+
+      - name: Report success status
+        if: steps.check-draft.outputs.is_draft == 'false' && steps.review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "$STATUS_URL" \
+            -f state=success \
+            -f context="Claude Auto Review" \
+            -f description="Review completed" \
+            -f target_url="$RUN_URL" || true
+
+      - name: Report failure status
+        if: always() && steps.check-draft.outputs.is_draft == 'false' && steps.review.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "$STATUS_URL" \
+            -f state=failure \
+            -f context="Claude Auto Review" \
+            -f description="Review failed" \
+            -f target_url="$RUN_URL" || true

--- a/docs/05_ADR/011_Claude_Code_Action導入.md
+++ b/docs/05_ADR/011_Claude_Code_Action導入.md
@@ -75,8 +75,30 @@ Anthropic 公式の GitHub Action。PRオープン時に自動レビュー、コ
 
 ### 関連ドキュメント
 
-- 実装: [`.github/workflows/claude-review.yml`](../../.github/workflows/claude-review.yml)
+- 実装: [`.github/workflows/claude-auto-review.yml`](../../.github/workflows/claude-auto-review.yml)
 - レビュー基準: [`CLAUDE.md`](../../CLAUDE.md) の「PRレビュー」セクション
+
+---
+
+## 補足: workflow_run イベントでのステータス報告
+
+`workflow_run` イベントでトリガーされるワークフローは、デフォルトブランチ（main）のコンテキストで実行されるため、PR のコミットにステータスが自動で紐付かない。
+
+この問題を解決するため、GitHub Status API を使って明示的にステータスを報告している:
+
+```yaml
+gh api "repos/{owner}/{repo}/statuses/{sha}" \
+  -f state=pending|success|failure \
+  -f context="Claude Auto Review" \
+  -f description="..." \
+  -f target_url="..." || true
+```
+
+`|| true` を付けることで、API エラー時もワークフローを継続する（ステータス報告は補助機能のため）。
+
+これにより、Ruleset で「Claude Auto Review」を必須チェックとして設定可能になる。
+
+参考: [Creating commit status checks](https://docs.github.com/en/rest/commits/statuses)
 
 ---
 
@@ -84,4 +106,5 @@ Anthropic 公式の GitHub Action。PRオープン時に自動レビュー、コ
 
 | 日付 | 変更内容 |
 |------|---------|
+| 2026-01-18 | workflow_run イベントでのステータス報告を追加 |
 | 2026-01-15 | 初版作成 |

--- a/prompts/runs/2026-01/2026-01-18_08_AutoReviewステータス報告.md
+++ b/prompts/runs/2026-01/2026-01-18_08_AutoReviewステータス報告.md
@@ -1,0 +1,60 @@
+# Auto Review ワークフローのステータス報告追加
+
+## 概要
+
+`workflow_run` イベントでトリガーされる Auto Review ワークフローに、GitHub Status API を使ったステータス報告機能を追加した。
+
+## 背景と目的
+
+`workflow_run` イベントはデフォルトブランチのコンテキストで実行されるため、PR のコミットにステータスが自動で紐付かない。このため、Ruleset で「Auto Review」を必須チェックに設定しても「Waiting for status to be reported」のままになっていた。
+
+## 実施内容
+
+### 1. GitHub Status API によるステータス報告
+
+PR のコミット SHA に対して明示的にステータスを報告:
+
+| タイミング | 状態 | 説明 |
+|-----------|------|------|
+| ジョブ開始時 | pending | "Running auto review..." |
+| Draft PR の場合 | success | "Skipped (draft PR)" |
+| レビュー成功時 | success | "Review completed" |
+| レビュー失敗時 | failure | "Review failed" |
+
+### 2. 実装の最適化
+
+stash から適用した実装を改善:
+
+- ジョブレベルで環境変数（`STATUS_URL`, `RUN_URL`）を定義し、重複を削減
+- 中間ステップ（`set-sha`）を削除し、GitHub 式を直接使用
+- `success()` / `failure()` の代わりに `steps.review.outcome` を使用して明示的に
+- failure ステップに `always()` を追加して確実に評価されるように
+
+## 成果物
+
+### 更新したファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `.github/workflows/claude-auto-review.yml` | Status API によるステータス報告を追加 |
+| `docs/05_ADR/011_Claude_Code_Action導入.md` | workflow_run でのステータス報告について追記 |
+
+### 関連 Issue
+
+- [#70 Auto Review ワークフローが PR のステータスチェックに反映されない](https://github.com/ka2kama/ringiflow/issues/70)
+
+## 設計判断と実装解説
+
+### `steps.<id>.outcome` vs `success()` / `failure()`
+
+`success()` / `failure()` はジョブ全体の状態を見るため、どのステップが原因で成功/失敗したか不明瞭になる場合がある。`steps.review.outcome` を使うことで、Claude Code Review ステップの結果を明示的にチェックできる。
+
+### `always()` の必要性
+
+GitHub Actions のデフォルト動作では、前のステップが失敗するとそれ以降のステップはスキップされる。failure ステータスを報告するステップを確実に評価させるため、`always()` を条件に追加した。
+
+## 学んだこと
+
+- `workflow_run` イベントでは PR のステータスチェックに自動で紐付かない
+- GitHub Status API を使って `repos/{owner}/{repo}/statuses/{sha}` に POST することで手動でステータスを設定できる
+- ジョブレベルの `env` でよく使う式を変数化すると重複を減らせる


### PR DESCRIPTION
## Summary

- `workflow_run` イベントは PR のステータスチェックに自動で紐付かないため、GitHub Status API を使って明示的にステータスを報告するように変更
- ジョブレベル環境変数で重複を削減し、`steps.review.outcome` で明示的にステップ結果をチェック

## Test plan

- [ ] Draft PR でワークフローをトリガーし、"Skipped (draft PR)" ステータスが報告されることを確認
- [ ] 通常の PR でワークフローをトリガーし、pending → success の流れでステータスが報告されることを確認
- [ ] Ruleset で "Auto Review" を必須チェックとして設定できることを確認

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)