### PR TITLE
fix(infra): セッション削除時にCSRFトークンも自動削除するように修正

### DIFF
--- a/backend/crates/infra/tests/session_test.rs
+++ b/backend/crates/infra/tests/session_test.rs
@@ -104,11 +104,28 @@ async fn test_削除後のセッションはnoneを返す() {
    let data = test_session_data(&tenant_id, &user_id);
 
    let session_id = manager.create(&data).await.unwrap();
+
+   // CSRF トークンも作成
+   manager
+      .create_csrf_token(&tenant_id, &session_id)
+      .await
+      .unwrap();
+
    manager.delete(&tenant_id, &session_id).await.unwrap();
 
+   // セッションが削除されている
    let result = manager.get(&tenant_id, &session_id).await;
    assert!(result.is_ok());
    assert!(result.unwrap().is_none());
+
+   // CSRF トークンも自動的に削除されている
+   assert!(
+      manager
+         .get_csrf_token(&tenant_id, &session_id)
+         .await
+         .unwrap()
+         .is_none()
+   );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `delete_all_for_tenant` でセッション削除時にCSRFトークンも自動的に削除
- セッションとCSRFトークンの削除を `delete_all_for_tenant` 1回の呼び出しで完結
- テストを拡張してCSRFトークン削除を検証

## 背景

セッションとCSRFトークンは従属関係にあり、呼び出し側が両方のメソッドを呼ぶ必要があると削除漏れのリスクがある。テナント退会時のデータ削除において漏れは重大なセキュリティ/コンプライアンス問題になるため、カプセル化を改善。

## Test plan

- [x] `session_test.rs` に CSRFトークン削除の検証テストを追加済み
- [x] `just check-all` 通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)