### PR TITLE
Claude Code Action で Dependabot からの PR を許可

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -94,6 +94,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # workflow_run イベントでは track_progress はサポートされていない
           track_progress: false
+          # Dependabot などの Bot からの PR を許可
+          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/claude-rules-check.yml
+++ b/.github/workflows/claude-rules-check.yml
@@ -82,6 +82,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: false
+          # Dependabot などの Bot からの PR を許可
+          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/docs/05_ADR/011_Claude_Code_Action導入.md
+++ b/docs/05_ADR/011_Claude_Code_Action導入.md
@@ -102,9 +102,31 @@ gh api "repos/{owner}/{repo}/statuses/{sha}" \
 
 ---
 
+## 補足: Bot からの PR 対応
+
+Claude Code Action はデフォルトで Bot からの PR を処理しない（セキュリティ上の理由）。
+
+Dependabot によるセキュリティアップデート PR など、信頼できる Bot からの PR にもレビューを実行するには、`allowed_bots` パラメータを設定する:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    allowed_bots: "dependabot[bot]"  # Dependabot を許可
+    # allowed_bots: "*"  # 全 Bot を許可（非推奨）
+```
+
+設定値:
+- `"dependabot[bot]"`: Dependabot のみ許可
+- `"dependabot[bot],renovate[bot]"`: 複数 Bot をカンマ区切りで許可
+- `"*"`: 全 Bot を許可（セキュリティリスクあり）
+- `""` (デフォルト): Bot を許可しない
+
+---
+
 ## 変更履歴
 
 | 日付 | 変更内容 |
 |------|---------|
+| 2026-01-25 | Bot からの PR 対応（allowed_bots）を追加 |
 | 2026-01-18 | workflow_run イベントでのステータス報告を追加 |
 | 2026-01-15 | 初版作成 |


### PR DESCRIPTION
## 概要

Dependabot が作成したセキュリティアップデート PR に対して、Claude Auto Review / Rules Check が失敗していた問題を修正。

## 変更内容

- `claude-auto-review.yml`: `allowed_bots: "dependabot[bot]"` を追加
- `claude-rules-check.yml`: `allowed_bots: "dependabot[bot]"` を追加
- ADR-011 に設定方法を追記

## 背景

PR #99（lodash セキュリティアップデート）で以下のエラーが発生:

```
Workflow initiated by non-human actor: dependabot (type: Bot). 
Add bot to allowed_bots list or use '*' to allow all bots.
```

Claude Code Action はデフォルトで Bot からの PR を処理しないため、信頼できる Bot（Dependabot）を明示的に許可する設定を追加した。

## テスト方法

このPRをマージ後、PR #99 の CI を再実行して Claude レビューが動作することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)