### PR TITLE
#116 Rules Check: max-turns 増加と grep/find 許可

### DIFF
--- a/.github/workflows/claude-rules-check.yml
+++ b/.github/workflows/claude-rules-check.yml
@@ -135,8 +135,8 @@ jobs:
               )"
               ```
           claude_args: |
-            --max-turns 30
-            --allowedTools "Read,Bash(cat:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
+            --max-turns 40
+            --allowedTools "Read,Bash(cat:*),Bash(grep:*),Bash(find:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
 
       - name: Check review decision
         id: review-decision


### PR DESCRIPTION
## Summary

Claude Rules Check の大規模 PR 対応を改善。

- `max-turns` を 30 → 40 に増加（Auto Review と同等）
- `allowedTools` に `Bash(grep:*)` と `Bash(find:*)` を追加

## Related

Closes #116

## Test plan

- [x] ワークフロー YAML の構文確認
- [x] 大規模 PR で再現テストは CI 完了後に確認予定

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)