### PR TITLE
ワークフロー申請機能のドキュメント整備と再発防止策

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -1,0 +1,115 @@
+---
+paths:
+  - "backend/apps/bff/src/handler/**/*.rs"
+  - "backend/apps/bff/src/main.rs"
+  - "openapi/**/*.yaml"
+---
+
+# API 実装時のルール
+
+このルールは BFF の公開 API エンドポイントを追加・変更する際に適用される。
+
+## 必須チェックリスト
+
+### 1. OpenAPI 仕様書の更新
+
+**ファイル:** [`openapi/openapi.yaml`](../../openapi/openapi.yaml)
+
+| 変更内容 | 更新箇所 |
+|---------|---------|
+| エンドポイント追加 | `paths` セクションにパスとメソッドを追加 |
+| エンドポイント変更 | `paths` セクションの該当箇所を修正 |
+| エンドポイント削除 | `paths` セクションから該当箇所を削除 |
+| リクエスト/レスポンス型の変更 | `components/schemas` の該当スキーマを修正 |
+| 共通パラメータの変更 | `components/parameters` の該当パラメータを修正 |
+| エラーレスポンスの変更 | `components/responses` の該当レスポンスを修正 |
+
+### 2. API 設計書との整合性確認
+
+[`docs/03_詳細設計書/03_API設計.md`](../../docs/03_詳細設計書/03_API設計.md) に記載された設計と一致しているか確認する。
+
+## OpenAPI 記述ガイドライン
+
+### エンドポイント定義の基本形
+
+```yaml
+/api/v1/resources:
+  post:
+    tags:
+      - resources
+    summary: リソース作成（短く）
+    description: |
+      詳細な説明。
+      複数行可。
+    operationId: createResource  # キャメルケース
+    security:
+      - sessionAuth: []
+    parameters:
+      - $ref: '#/components/parameters/XTenantId'
+      - $ref: '#/components/parameters/XCsrfToken'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateResourceRequest'
+    responses:
+      '201':
+        description: 作成成功
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResourceResponse'
+      '400':
+        description: バリデーションエラー
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProblemDetails'
+      '401':
+        $ref: '#/components/responses/Unauthorized'
+      '404':
+        $ref: '#/components/responses/NotFound'
+```
+
+### スキーマ定義の基本形
+
+```yaml
+CreateResourceRequest:
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      description: リソース名
+      minLength: 1
+      maxLength: 255
+      example: "サンプル"
+```
+
+### 共通パターン
+
+| パターン | 使用方法 |
+|---------|---------|
+| 認証必須エンドポイント | `security: [sessionAuth: []]` |
+| 状態変更（POST/PUT/DELETE） | `X-CSRF-Token` パラメータ必須 |
+| テナント分離 | `X-Tenant-ID` パラメータ必須 |
+| エラーレスポンス | `$ref: '#/components/schemas/ProblemDetails'` |
+
+## AI エージェントへの指示
+
+API エンドポイントを追加・変更・削除した場合:
+
+1. **実装完了後、OpenAPI 仕様書を必ず更新する**
+2. コミット前に `just check-all` で全体を確認する
+
+**禁止事項:**
+
+- 実装と OpenAPI 仕様書が乖離した状態でコミットすること
+- エラーレスポンスの RFC 7807 形式からの逸脱
+
+## 参照
+
+- API 設計書: [docs/03_詳細設計書/03_API設計.md](../../docs/03_詳細設計書/03_API設計.md)
+- OpenAPI 仕様: [openapi/openapi.yaml](../../openapi/openapi.yaml)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,3 +24,4 @@ Issue との関連:
 -->
 
 - [ ] `just check-all` が通る
+- [ ] API エンドポイントを追加・変更・削除した場合: OpenAPI 仕様書 (`openapi/openapi.yaml`) を更新した

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,17 @@ just clean-branches  # マージ後のローカルブランチ削除
 
 **禁止:** DB 接続が必要なテストを `src/` に配置、`sqlx-prepare` の省略
 
+## API 実装時の必須対応
+
+BFF の公開 API エンドポイントを追加・変更・削除した場合、以下を必ず実施する。
+
+→ 詳細: [`.claude/rules/api.md`](.claude/rules/api.md)
+
+1. OpenAPI 仕様書 ([`openapi/openapi.yaml`](openapi/openapi.yaml)) を更新
+2. API 設計書との整合性を確認
+
+**禁止:** 実装と OpenAPI 仕様書が乖離した状態でコミットすること
+
 ## 開発ツール追加時の必須対応
 
 新しい開発ツールを追加する場合、以下を同時に更新:

--- a/backend/apps/bff/src/handler/workflow.rs
+++ b/backend/apps/bff/src/handler/workflow.rs
@@ -44,7 +44,7 @@ pub enum TenantIdError {
 }
 
 impl IntoResponse for TenantIdError {
-   fn into_response(self) -> axum::response::Response {
+   fn into_response(self) -> Response {
       let (status, detail) = match self {
          TenantIdError::Missing => (StatusCode::BAD_REQUEST, "X-Tenant-ID ヘッダーが必要です"),
          TenantIdError::InvalidFormat => (StatusCode::BAD_REQUEST, "X-Tenant-ID の形式が不正です"),

--- a/docs/07_実装解説/04_ワークフロー申請機能/00_概要.md
+++ b/docs/07_実装解説/04_ワークフロー申請機能/00_概要.md
@@ -10,15 +10,16 @@
 
 ## Phase 構成
 
-| Phase | 内容 | 状態 |
-|-------|------|------|
-| Phase 1 | WorkflowDefinitionRepository | ✅ 完了 |
-| Phase 2 | WorkflowInstanceRepository | ✅ 完了 |
-| Phase 3 | WorkflowStepRepository | ✅ 完了 |
-| Phase 4 | ワークフロー作成ユースケース | ✅ 完了 |
-| Phase 5 | Core Service API | ✅ 完了 |
-| Phase 6 | (Phase 5 に統合) | - |
-| Phase 7 | BFF API | ✅ 完了 |
+| Phase | 内容 | 状態 | 解説 |
+|-------|------|------|------|
+| Phase 1 | WorkflowDefinitionRepository | ✅ 完了 | [解説](./01_Phase1_WorkflowDefinitionRepository.md) |
+| Phase 2 | WorkflowInstanceRepository | ✅ 完了 | [解説](./02_Phase2_WorkflowInstanceRepository.md) |
+| Phase 3 | WorkflowStepRepository | ✅ 完了 | [解説](./03_Phase3_WorkflowStepRepository.md) |
+| Phase 4 | ワークフロー作成ユースケース | ✅ 完了 | [解説](./04_Phase4_WorkflowUseCase.md) |
+| Phase 5 | Core Service API | ✅ 完了 | [解説](./05_Phase5_CoreServiceAPI.md) |
+| Phase 6 | (Phase 5 に統合) | - | - |
+| Phase 7 | BFF API | ✅ 完了 | [解説](./06_Phase7_BFFAPI.md) |
+| - | 全体フロー | ✅ 完了 | [解説](./07_全体フロー.md) |
 
 ## 設計書
 

--- a/docs/07_実装解説/04_ワークフロー申請機能/07_全体フロー.md
+++ b/docs/07_実装解説/04_ワークフロー申請機能/07_全体フロー.md
@@ -1,0 +1,400 @@
+# ワークフロー申請機能 - 全体フロー
+
+## 概要
+
+このドキュメントでは、ワークフロー申請機能の全体的なデータフローと、各レイヤーのファイル・関数の連携を解説する。
+
+---
+
+## アーキテクチャ概観
+
+```mermaid
+flowchart TB
+    subgraph Frontend ["Frontend (Elm)"]
+        Browser["ブラウザ"]
+    end
+
+    subgraph BFF ["BFF (backend/apps/bff)"]
+        BFFHandler["handler/workflow.rs"]
+        BFFClient["client/core_service.rs"]
+        SessionMgr["SessionManager"]
+    end
+
+    subgraph Core ["Core Service (backend/apps/core-service)"]
+        CoreHandler["handler/workflow.rs"]
+        UseCase["usecase/workflow.rs"]
+    end
+
+    subgraph Infra ["Infrastructure (backend/crates/infra)"]
+        DefRepo["WorkflowDefinitionRepository"]
+        InstRepo["WorkflowInstanceRepository"]
+        StepRepo["WorkflowStepRepository"]
+    end
+
+    subgraph DB ["PostgreSQL"]
+        DefTable["workflow_definitions"]
+        InstTable["workflow_instances"]
+        StepTable["workflow_steps"]
+    end
+
+    Browser -->|"POST /api/v1/workflows"| BFFHandler
+    BFFHandler --> SessionMgr
+    BFFHandler --> BFFClient
+    BFFClient -->|"POST /internal/workflows"| CoreHandler
+    CoreHandler --> UseCase
+    UseCase --> DefRepo
+    UseCase --> InstRepo
+    UseCase --> StepRepo
+    DefRepo --> DefTable
+    InstRepo --> InstTable
+    StepRepo --> StepTable
+```
+
+---
+
+## 主要コンポーネント一覧
+
+### BFF 層
+
+| ファイル | 責務 |
+|---------|------|
+| [`backend/apps/bff/src/handler/workflow.rs`](../../../backend/apps/bff/src/handler/workflow.rs) | 公開 API ハンドラ。セッション検証、Core Service 呼び出し |
+| [`backend/apps/bff/src/client/core_service.rs`](../../../backend/apps/bff/src/client/core_service.rs) | Core Service への HTTP クライアント |
+| [`backend/apps/bff/src/main.rs`](../../../backend/apps/bff/src/main.rs) | ルーティング定義 |
+
+### Core Service 層
+
+| ファイル | 責務 |
+|---------|------|
+| [`backend/apps/core-service/src/handler/workflow.rs`](../../../backend/apps/core-service/src/handler/workflow.rs) | 内部 API ハンドラ。リクエスト変換、UseCase 呼び出し |
+| [`backend/apps/core-service/src/usecase/workflow.rs`](../../../backend/apps/core-service/src/usecase/workflow.rs) | ビジネスロジック。ワークフロー作成・申請処理 |
+| [`backend/apps/core-service/src/error.rs`](../../../backend/apps/core-service/src/error.rs) | エラー型定義。RFC 7807 変換 |
+| [`backend/apps/core-service/src/main.rs`](../../../backend/apps/core-service/src/main.rs) | ルーティング定義、DI 設定 |
+
+### Infrastructure 層
+
+| ファイル | 責務 |
+|---------|------|
+| [`backend/crates/infra/src/repository/workflow_definition_repository.rs`](../../../backend/crates/infra/src/repository/workflow_definition_repository.rs) | ワークフロー定義の永続化 |
+| [`backend/crates/infra/src/repository/workflow_instance_repository.rs`](../../../backend/crates/infra/src/repository/workflow_instance_repository.rs) | ワークフローインスタンスの永続化 |
+| [`backend/crates/infra/src/repository/workflow_step_repository.rs`](../../../backend/crates/infra/src/repository/workflow_step_repository.rs) | 承認ステップの永続化 |
+
+---
+
+## フロー 1: ワークフロー作成（POST /api/v1/workflows）
+
+### シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Browser as ブラウザ
+    participant BFF as BFF Handler
+    participant Session as SessionManager
+    participant Client as CoreServiceClient
+    participant Core as Core Handler
+    participant UC as WorkflowUseCase
+    participant DefRepo as DefinitionRepository
+    participant InstRepo as InstanceRepository
+    participant DB as PostgreSQL
+
+    Browser->>BFF: POST /api/v1/workflows
+    Note over Browser,BFF: Cookie: session_id<br/>Header: X-Tenant-ID
+
+    BFF->>BFF: extract_tenant_id()
+    BFF->>Session: get(tenant_id, session_id)
+    Session-->>BFF: SessionData { tenant_id, user_id }
+
+    BFF->>Client: create_workflow(req)
+    Client->>Core: POST /internal/workflows
+    Note over Client,Core: tenant_id, user_id を<br/>リクエストボディに含める
+
+    Core->>Core: ID を Uuid → ドメイン型に変換
+    Core->>UC: create_workflow(input, tenant_id, user_id)
+
+    UC->>DefRepo: find_by_id(definition_id, tenant_id)
+    DefRepo->>DB: SELECT FROM workflow_definitions
+    DB-->>DefRepo: WorkflowDefinition
+    DefRepo-->>UC: Option<WorkflowDefinition>
+
+    UC->>UC: 定義が公開済みか検証
+    UC->>UC: WorkflowInstance::new()
+    UC->>InstRepo: save(instance)
+    InstRepo->>DB: INSERT INTO workflow_instances
+    DB-->>InstRepo: OK
+    InstRepo-->>UC: Ok(())
+
+    UC-->>Core: Ok(WorkflowInstance)
+    Core->>Core: WorkflowInstance → DTO 変換
+    Core-->>Client: 201 Created + JSON
+    Client-->>BFF: WorkflowResponse
+    BFF-->>Browser: 201 Created + JSON
+```
+
+### 処理ステップ詳細
+
+| ステップ | レイヤー | ファイル:関数 | 処理内容 |
+|---------|---------|---------------|----------|
+| 1 | BFF | `handler/workflow.rs:create_workflow()` | X-Tenant-ID ヘッダーを抽出 |
+| 2 | BFF | `handler/workflow.rs:get_session()` | Cookie からセッションを取得、認証検証 |
+| 3 | BFF | `client/core_service.rs:create_workflow()` | Core Service へ HTTP POST |
+| 4 | Core | `handler/workflow.rs:create_workflow()` | Uuid をドメイン型に変換 |
+| 5 | Core | `usecase/workflow.rs:create_workflow()` | ビジネスロジック実行 |
+| 6 | Infra | `workflow_definition_repository.rs:find_by_id()` | 定義を DB から取得 |
+| 7 | Core | `usecase/workflow.rs` | 定義が `published` か検証 |
+| 8 | Domain | `WorkflowInstance::new()` | インスタンスを `draft` 状態で生成 |
+| 9 | Infra | `workflow_instance_repository.rs:save()` | DB に INSERT (UPSERT) |
+| 10 | Core | `handler/workflow.rs` | `WorkflowInstance` → `WorkflowInstanceDto` 変換 |
+
+---
+
+## フロー 2: ワークフロー申請（POST /api/v1/workflows/{id}/submit）
+
+### シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant Browser as ブラウザ
+    participant BFF as BFF Handler
+    participant Session as SessionManager
+    participant Client as CoreServiceClient
+    participant Core as Core Handler
+    participant UC as WorkflowUseCase
+    participant DefRepo as DefinitionRepository
+    participant InstRepo as InstanceRepository
+    participant StepRepo as StepRepository
+    participant DB as PostgreSQL
+
+    Browser->>BFF: POST /api/v1/workflows/{id}/submit
+    Note over Browser,BFF: assigned_to (承認者ID)
+
+    BFF->>BFF: extract_tenant_id()
+    BFF->>Session: get(tenant_id, session_id)
+    Session-->>BFF: SessionData
+
+    BFF->>Client: submit_workflow(workflow_id, req)
+    Client->>Core: POST /internal/workflows/{id}/submit
+
+    Core->>UC: submit_workflow(input, instance_id, tenant_id)
+
+    UC->>InstRepo: find_by_id(instance_id, tenant_id)
+    InstRepo->>DB: SELECT FROM workflow_instances
+    DB-->>InstRepo: WorkflowInstance
+    InstRepo-->>UC: Option<WorkflowInstance>
+
+    UC->>UC: status == draft か検証
+
+    UC->>DefRepo: find_by_id(definition_id, tenant_id)
+    DefRepo->>DB: SELECT FROM workflow_definitions
+    DB-->>DefRepo: WorkflowDefinition
+    DefRepo-->>UC: Option<WorkflowDefinition>
+
+    UC->>UC: WorkflowStep::new()
+    UC->>UC: step.activated()
+    UC->>UC: instance.submitted()
+    UC->>UC: instance.with_current_step()
+
+    UC->>InstRepo: save(in_progress_instance)
+    InstRepo->>DB: UPDATE workflow_instances
+    DB-->>InstRepo: OK
+
+    UC->>StepRepo: save(active_step)
+    StepRepo->>DB: INSERT INTO workflow_steps
+    DB-->>StepRepo: OK
+
+    UC-->>Core: Ok(WorkflowInstance)
+    Core-->>Client: 200 OK + JSON
+    Client-->>BFF: WorkflowResponse
+    BFF-->>Browser: 200 OK + JSON
+```
+
+### 処理ステップ詳細
+
+| ステップ | レイヤー | ファイル:関数 | 処理内容 |
+|---------|---------|---------------|----------|
+| 1 | BFF | `handler/workflow.rs:submit_workflow()` | パスパラメータから workflow_id を抽出 |
+| 2 | BFF | `handler/workflow.rs:get_session()` | 認証検証 |
+| 3 | BFF | `client/core_service.rs:submit_workflow()` | Core Service へ HTTP POST |
+| 4 | Core | `handler/workflow.rs:submit_workflow()` | ID 変換 |
+| 5 | Core | `usecase/workflow.rs:submit_workflow()` | ビジネスロジック開始 |
+| 6 | Infra | `workflow_instance_repository.rs:find_by_id()` | インスタンスを取得 |
+| 7 | Core | `usecase/workflow.rs` | `status == draft` か検証 |
+| 8 | Infra | `workflow_definition_repository.rs:find_by_id()` | 定義を取得（将来の拡張用） |
+| 9 | Domain | `WorkflowStep::new()` | 承認ステップを生成 |
+| 10 | Domain | `step.activated()` | ステップを active 状態に |
+| 11 | Domain | `instance.submitted()` | `draft` → `pending` 遷移 |
+| 12 | Domain | `instance.with_current_step()` | `pending` → `in_progress` 遷移 |
+| 13 | Infra | `workflow_instance_repository.rs:save()` | インスタンスを更新 |
+| 14 | Infra | `workflow_step_repository.rs:save()` | ステップを保存 |
+
+---
+
+## 状態遷移
+
+### WorkflowInstance の状態
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft: new()
+    Draft --> Pending: submitted()
+    Pending --> InProgress: with_current_step()
+    InProgress --> Approved: approve() [将来実装]
+    InProgress --> Rejected: reject() [将来実装]
+    Approved --> [*]
+    Rejected --> [*]
+```
+
+### WorkflowStep の状態
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: new()
+    Pending --> Active: activated()
+    Active --> Approved: approve() [将来実装]
+    Active --> Rejected: reject() [将来実装]
+    Approved --> [*]
+    Rejected --> [*]
+```
+
+---
+
+## データ変換の流れ
+
+### リクエストの変換
+
+```
+[Frontend]
+    CreateWorkflowRequest (BFF公開API用)
+        ├── definition_id: Uuid
+        ├── title: String
+        └── form_data: serde_json::Value
+
+    ↓ BFF: セッションから tenant_id, user_id を追加
+
+[BFF → Core Service]
+    CreateWorkflowRequest (内部API用)
+        ├── definition_id: Uuid
+        ├── title: String
+        ├── form_data: serde_json::Value
+        ├── tenant_id: Uuid      ← 追加
+        └── user_id: Uuid        ← 追加
+
+    ↓ Core Handler: Uuid → ドメイン型
+
+[UseCase]
+    CreateWorkflowInput
+        ├── definition_id: WorkflowDefinitionId
+        ├── title: String
+        └── form_data: JsonValue
+    +
+    tenant_id: TenantId
+    user_id: UserId
+```
+
+### レスポンスの変換
+
+```
+[UseCase → Core Handler]
+    WorkflowInstance (ドメインモデル)
+
+    ↓ Core Handler: From<WorkflowInstance> for WorkflowInstanceDto
+
+[Core Service → BFF]
+    WorkflowInstanceDto
+        ├── id: String
+        ├── title: String
+        ├── status: String (Debug形式)
+        ├── ...
+        └── updated_at: String (RFC3339)
+
+    ↓ BFF: From<WorkflowInstanceDto> for WorkflowData
+
+[BFF → Frontend]
+    WorkflowResponse
+        └── data: WorkflowData
+```
+
+---
+
+## エラーハンドリングの流れ
+
+### エラー伝播
+
+```mermaid
+flowchart LR
+    subgraph Infra ["Infrastructure"]
+        InfraErr["InfraError"]
+    end
+
+    subgraph Core ["Core Service"]
+        CoreErr["CoreError"]
+        CoreResp["RFC 7807 Response"]
+    end
+
+    subgraph BFF ["BFF"]
+        ClientErr["CoreServiceError"]
+        BFFResp["RFC 7807 Response"]
+    end
+
+    InfraErr -->|"map_err"| CoreErr
+    CoreErr -->|"IntoResponse"| CoreResp
+    CoreResp -->|"HTTP 4xx/5xx"| ClientErr
+    ClientErr -->|"match"| BFFResp
+```
+
+### エラー種別とステータスコード
+
+| エラー | Core Service | BFF | HTTP Status |
+|-------|-------------|-----|-------------|
+| 定義が見つからない | `CoreError::NotFound` | `CoreServiceError::WorkflowDefinitionNotFound` | 404 |
+| インスタンスが見つからない | `CoreError::NotFound` | `CoreServiceError::WorkflowInstanceNotFound` | 404 |
+| draft 以外の申請 | `CoreError::BadRequest` | `CoreServiceError::ValidationError` | 400 |
+| 未公開定義での作成 | `CoreError::BadRequest` | `CoreServiceError::ValidationError` | 400 |
+| DB エラー | `CoreError::Internal` | `CoreServiceError::Unexpected` | 500 |
+
+---
+
+## テナント分離
+
+すべてのデータアクセスでテナント ID を検証し、クロステナントアクセスを防止する。
+
+### 検証ポイント
+
+| レイヤー | 検証方法 |
+|---------|---------|
+| BFF | セッションの tenant_id と X-Tenant-ID ヘッダーを照合 |
+| Repository | すべての SELECT/UPDATE に `WHERE tenant_id = $N` を含める |
+| workflow_steps | 親テーブル (workflow_instances) と JOIN してテナントを検証 |
+
+### SQL での分離例
+
+```sql
+-- workflow_instances の取得
+SELECT * FROM workflow_instances
+WHERE id = $1 AND tenant_id = $2;
+
+-- workflow_steps の取得（JOIN による分離）
+SELECT ws.* FROM workflow_steps ws
+INNER JOIN workflow_instances wi ON ws.instance_id = wi.id
+WHERE ws.id = $1 AND wi.tenant_id = $2;
+```
+
+---
+
+## 関連ドキュメント
+
+- [Phase 1: WorkflowDefinitionRepository](./01_Phase1_WorkflowDefinitionRepository.md)
+- [Phase 2: WorkflowInstanceRepository](./02_Phase2_WorkflowInstanceRepository.md)
+- [Phase 3: WorkflowStepRepository](./03_Phase3_WorkflowStepRepository.md)
+- [Phase 4: WorkflowUseCase](./04_Phase4_WorkflowUseCase.md)
+- [Phase 5: Core Service API](./05_Phase5_CoreServiceAPI.md)
+- [Phase 7: BFF API](./06_Phase7_BFFAPI.md)
+- [API 設計書](../../03_詳細設計書/03_API設計.md)
+- [データベース設計書](../../03_詳細設計書/02_データベース設計.md)
+
+---
+
+## 変更履歴
+
+| 日付 | 変更内容 | 担当 |
+|------|---------|------|
+| 2026-01-26 | 全体フロードキュメントを追加 | - |

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -162,6 +162,131 @@ paths:
           $ref: '#/components/responses/Unauthorized'
 
   # ============================================================
+  # ワークフロー API
+  # ============================================================
+  /api/v1/workflows:
+    post:
+      tags:
+        - workflows
+      summary: ワークフロー作成（下書き）
+      description: |
+        ワークフロー定義を元に、新しいワークフローインスタンスを下書き状態で作成する。
+
+        作成後は `draft` 状態となり、`/submit` で申請するまで承認フローは開始されない。
+      operationId: createWorkflow
+      security:
+        - sessionAuth: []
+      parameters:
+        - $ref: '#/components/parameters/XTenantId'
+        - $ref: '#/components/parameters/XCsrfToken'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWorkflowRequest'
+            example:
+              definition_id: "123e4567-e89b-12d3-a456-426614174000"
+              title: "経費精算申請"
+              form_data:
+                amount: 50000
+                description: "出張費用"
+      responses:
+        '201':
+          description: ワークフロー作成成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowResponse'
+        '400':
+          description: バリデーションエラー（定義が未公開など）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                type: https://ringiflow.example.com/errors/validation-error
+                title: Validation Error
+                status: 400
+                detail: 公開されていないワークフロー定義です
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: ワークフロー定義が見つからない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                type: https://ringiflow.example.com/errors/workflow-definition-not-found
+                title: Workflow Definition Not Found
+                status: 404
+                detail: ワークフロー定義が見つかりません
+
+  /api/v1/workflows/{id}/submit:
+    post:
+      tags:
+        - workflows
+      summary: ワークフロー申請
+      description: |
+        下書き状態のワークフローを申請する。
+
+        申請すると承認ステップが作成され、ワークフローは `in_progress` 状態に遷移する。
+        MVP では1段階承認のみサポート。
+      operationId: submitWorkflow
+      security:
+        - sessionAuth: []
+      parameters:
+        - $ref: '#/components/parameters/XTenantId'
+        - $ref: '#/components/parameters/XCsrfToken'
+        - name: id
+          in: path
+          required: true
+          description: ワークフローインスタンス ID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitWorkflowRequest'
+            example:
+              assigned_to: "987fcdeb-51a2-3d4e-b567-890123456789"
+      responses:
+        '200':
+          description: 申請成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowResponse'
+        '400':
+          description: バリデーションエラー（下書き以外の申請など）
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                type: https://ringiflow.example.com/errors/validation-error
+                title: Validation Error
+                status: 400
+                detail: 下書き状態のワークフローのみ申請できます
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: ワークフローインスタンスが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+              example:
+                type: https://ringiflow.example.com/errors/workflow-instance-not-found
+                title: Workflow Instance Not Found
+                status: 404
+                detail: ワークフローインスタンスが見つかりません
+
+  # ============================================================
   # ヘルスチェック API
   # ============================================================
   /health:
@@ -208,7 +333,133 @@ components:
       name: session_id
       description: HTTPOnly セッション Cookie
 
+  parameters:
+    XTenantId:
+      name: X-Tenant-ID
+      in: header
+      required: true
+      description: テナント ID
+      schema:
+        type: string
+        format: uuid
+      example: "123e4567-e89b-12d3-a456-426614174000"
+
+    XCsrfToken:
+      name: X-CSRF-Token
+      in: header
+      required: true
+      description: CSRF トークン（/auth/csrf で取得）
+      schema:
+        type: string
+      example: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
   schemas:
+    # ============================================================
+    # ワークフロー関連
+    # ============================================================
+    CreateWorkflowRequest:
+      type: object
+      required:
+        - definition_id
+        - title
+        - form_data
+      properties:
+        definition_id:
+          type: string
+          format: uuid
+          description: ワークフロー定義 ID
+        title:
+          type: string
+          description: ワークフロータイトル
+          minLength: 1
+          maxLength: 255
+          example: "経費精算申請"
+        form_data:
+          type: object
+          description: フォームデータ（定義に応じた任意の JSON）
+          additionalProperties: true
+          example:
+            amount: 50000
+            description: "出張費用"
+
+    SubmitWorkflowRequest:
+      type: object
+      required:
+        - assigned_to
+      properties:
+        assigned_to:
+          type: string
+          format: uuid
+          description: 承認者のユーザー ID
+
+    WorkflowResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          $ref: '#/components/schemas/WorkflowInstance'
+
+    WorkflowInstance:
+      type: object
+      required:
+        - id
+        - title
+        - definition_id
+        - status
+        - form_data
+        - initiated_by
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: ワークフローインスタンス ID
+        title:
+          type: string
+          description: ワークフロータイトル
+        definition_id:
+          type: string
+          format: uuid
+          description: ワークフロー定義 ID
+        status:
+          type: string
+          enum: [Draft, Pending, InProgress, Approved, Rejected, Cancelled]
+          description: |
+            ワークフローの状態:
+            - Draft: 下書き
+            - Pending: 申請待ち
+            - InProgress: 承認中
+            - Approved: 承認済み
+            - Rejected: 却下
+            - Cancelled: キャンセル
+        form_data:
+          type: object
+          description: フォームデータ
+          additionalProperties: true
+        initiated_by:
+          type: string
+          format: uuid
+          description: 申請者のユーザー ID
+        current_step_id:
+          type: string
+          nullable: true
+          description: 現在の承認ステップ ID
+        submitted_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: 申請日時
+        created_at:
+          type: string
+          format: date-time
+          description: 作成日時
+        updated_at:
+          type: string
+          format: date-time
+          description: 更新日時
+
     # ============================================================
     # 認証関連
     # ============================================================


### PR DESCRIPTION
## Issue

Related to #35

## Summary

PR #114 で実装したワークフロー申請機能について、以下を追加・整備した。

### ドキュメント
- **全体フロードキュメント** (`docs/07_実装解説/04_ワークフロー申請機能/07_全体フロー.md`)
  - シーケンス図によるリクエストフローの可視化
  - 各レイヤーのファイル・関数の対応表
  - 状態遷移図、データ変換の流れ、エラーハンドリング

### OpenAPI 仕様書
- `POST /api/v1/workflows` - ワークフロー作成
- `POST /api/v1/workflows/{id}/submit` - ワークフロー申請
- 関連スキーマ・パラメータの追加

### 再発防止策（OpenAPI 更新漏れ防止）
- `.claude/rules/api.md` - API 実装時の必須ルール
- `CLAUDE.md` - API 実装時の必須対応セクション追加
- PR テンプレート - OpenAPI 更新チェック項目追加

### その他
- 冗長な import を修正 (`axum::response::Response` → `Response`)

## Test plan

- [x] `just check-all` が通る
- [x] API エンドポイントを追加・変更・削除した場合: OpenAPI 仕様書 (`openapi/openapi.yaml`) を更新した
- [x] OpenAPI 仕様書の検証: `npx -y @apidevtools/swagger-cli validate openapi/openapi.yaml` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)