### PR TITLE
#132 Claude Auto Review が PR コメントを考慮できるようにする

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -96,10 +96,10 @@ jobs:
 
           # PR コメントと Review コメントを取得（最新20件、claude[bot] 自身を除外）
           COMMENTS=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.user.login != "claude[bot]") | {author: .user.login, body: .body, created_at: .created_at}] | last(20)' 2>/dev/null || echo "[]")
+            --jq '[.[] | select(.user.login != "claude[bot]") | {author: .user.login, body: .body, created_at: .created_at}] | .[-20:]' 2>/dev/null || echo "[]")
 
           REVIEW_COMMENTS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments" \
-            --jq '[.[] | select(.user.login != "claude[bot]") | {author: .user.login, body: .body, path: .path, created_at: .created_at}] | last(20)' 2>/dev/null || echo "[]")
+            --jq '[.[] | select(.user.login != "claude[bot]") | {author: .user.login, body: .body, path: .path, created_at: .created_at}] | .[-20:]' 2>/dev/null || echo "[]")
 
           # JSON を環境ファイルに出力（multiline safe）
           {


### PR DESCRIPTION
## Issue

Closes #132

## Summary

Claude Auto Review が PR コメントを考慮してレビューできるようにする。

- PR コメントとレビューコメントを事前取得するステップを追加
- 取得したコメントをプロンプトに埋め込み、文脈を理解できるようにする
- 「過去の議論を踏まえた判断」ルールを追加

## Test plan

最終 Phase 完了後に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)