### PR TITLE
#148 Rename Api.Http module to Api for clearer hierarchy

### DIFF
--- a/docs/07_実装解説/04_ワークフロー申請機能/08_Phase8_フロントエンドAPIクライアント.md
+++ b/docs/07_実装解説/04_ワークフロー申請機能/08_Phase8_フロントエンドAPIクライアント.md
@@ -37,7 +37,7 @@ Phase 7 で実装した BFF API は POST エンドポイントのみだった。
 | `Data/WorkflowInstance.elm` | ワークフローインスタンス（申請案件） |
 | `Data/FormField.elm` | 動的フォームフィールド定義 |
 
-### 2. HTTP ヘルパー（`Api/Http.elm`）
+### 2. HTTP ヘルパー（`Api.elm`）
 
 BFF への API リクエストに必要な共通処理を提供。
 
@@ -110,7 +110,7 @@ Phase 1 では API クライアント層のみ実装し、UI は Phase 2 で実�
 NoUnused.Modules.rule
     -- TODO: Phase 1 で作成した API/Data モジュール。Phase 2 で UI 実装後に除外設定を削除する
     |> Rule.ignoreErrorsForFiles
-        [ "src/Api/Http.elm"
+        [ "src/Api.elm"
         , "src/Api/Workflow.elm"
         , ...
         ]

--- a/docs/07_実装解説/05_ワークフロー承認却下機能/05_Phase6_フロントエンド.md
+++ b/docs/07_実装解説/05_ワークフロー承認却下機能/05_Phase6_フロントエンド.md
@@ -9,7 +9,7 @@
 ### 1. エラー型の拡張
 
 ```elm
--- Api/Http.elm
+-- Api.elm
 type ApiError
     = BadRequest ProblemDetails
     | Unauthorized

--- a/docs/07_実装解説/05_ワークフロー承認却下機能/06_全体フロー.md
+++ b/docs/07_実装解説/05_ワークフロー承認却下機能/06_全体フロー.md
@@ -123,7 +123,7 @@ sequenceDiagram
 |---------|------|
 | [`frontend/src/Page/Workflow/Detail.elm`](../../../frontend/src/Page/Workflow/Detail.elm) | 詳細ページ。承認/却下ボタン、エラー表示 |
 | [`frontend/src/Api/Workflow.elm`](../../../frontend/src/Api/Workflow.elm) | API クライアント。`approveStep`, `rejectStep` |
-| [`frontend/src/Api/Http.elm`](../../../frontend/src/Api/Http.elm) | HTTP ヘルパー。`Conflict` エラー型 |
+| [`frontend/src/Api.elm`](../../../frontend/src/Api.elm) | HTTP ヘルパー。`Conflict` エラー型 |
 | [`frontend/src/Data/WorkflowInstance.elm`](../../../frontend/src/Data/WorkflowInstance.elm) | データ型。`version`, `steps`, `StepStatus` |
 
 ### BFF 層

--- a/docs/07_実装解説/06_ダッシュボード/02_Phase4_フロントエンド.md
+++ b/docs/07_実装解説/06_ダッシュボード/02_Phase4_フロントエンド.md
@@ -95,10 +95,10 @@ Nested TEA 統合のため、以下の箇所を更新:
 
 ```elm
 -- 採用: 型のみインポート
-import Api.Http exposing (ApiError)
+import Api exposing (ApiError)
 
 -- 不採用: コンストラクタも公開
-import Api.Http exposing (ApiError(..))
+import Api exposing (ApiError(..))
 ```
 
 なぜこの設計か:

--- a/frontend/review/src/ReviewConfig.elm
+++ b/frontend/review/src/ReviewConfig.elm
@@ -27,7 +27,7 @@ config =
       NoUnused.CustomTypeConstructorArgs.rule
         -- TODO: Api/Data モジュールの一部フィールドは Phase 3（申請一覧・詳細）で使用予定
         |> Rule.ignoreErrorsForFiles
-            [ "src/Api/Http.elm"
+            [ "src/Api.elm"
             , "src/Data/FormField.elm"
             , "src/Data/WorkflowInstance.elm"
             ]
@@ -41,7 +41,7 @@ config =
         |> Rule.ignoreErrorsForFiles [ "src/Ports.elm" ]
         -- TODO: Api/Data モジュールの一部関数・型は Phase 3（申請一覧・詳細）で使用予定
         |> Rule.ignoreErrorsForFiles
-            [ "src/Api/Http.elm"
+            [ "src/Api.elm"
             , "src/Api/Workflow.elm"
             , "src/Api/WorkflowDefinition.elm"
             , "src/Data/FormField.elm"

--- a/frontend/src/Api.elm
+++ b/frontend/src/Api.elm
@@ -1,4 +1,4 @@
-module Api.Http exposing
+module Api exposing
     ( ApiError(..)
     , ProblemDetails
     , RequestConfig
@@ -17,9 +17,9 @@ CSRF トークン、X-Tenant-ID ヘッダーの付与と RFC 7807 エラーハ�
 
 ## 使用例
 
-    import Api.Http as Api
+    import Api
 
-    fetchDefinitions : RequestConfig -> (Result Api.ApiError (List WorkflowDefinition) -> msg) -> Cmd msg
+    fetchDefinitions : Api.RequestConfig -> (Result Api.ApiError (List WorkflowDefinition) -> msg) -> Cmd msg
     fetchDefinitions config toMsg =
         Api.get
             { config = config

--- a/frontend/src/Api/Auth.elm
+++ b/frontend/src/Api/Auth.elm
@@ -23,7 +23,7 @@ BFF の `/auth` エンドポイントへのアクセスを提供。
 
 -}
 
-import Api.Http as Api exposing (ApiError, RequestConfig)
+import Api exposing (ApiError, RequestConfig)
 import Json.Decode as Decode exposing (Decoder)
 import Shared exposing (User)
 

--- a/frontend/src/Api/Dashboard.elm
+++ b/frontend/src/Api/Dashboard.elm
@@ -17,7 +17,7 @@ BFF の `/api/v1/dashboard` エンドポイントへのアクセスを提供。
 
 -}
 
-import Api.Http as Api exposing (ApiError, RequestConfig)
+import Api exposing (ApiError, RequestConfig)
 import Data.Dashboard as Dashboard exposing (DashboardStats)
 
 

--- a/frontend/src/Api/Task.elm
+++ b/frontend/src/Api/Task.elm
@@ -24,7 +24,7 @@ BFF の `/api/v1/tasks` エンドポイントへのアクセスを提供。
 
 -}
 
-import Api.Http as Api exposing (ApiError, RequestConfig)
+import Api exposing (ApiError, RequestConfig)
 import Data.Task as Task exposing (TaskDetail, TaskItem)
 
 

--- a/frontend/src/Api/Workflow.elm
+++ b/frontend/src/Api/Workflow.elm
@@ -32,7 +32,7 @@ BFF の `/api/v1/workflows` エンドポイントへのアクセスを提供。
 
 -}
 
-import Api.Http as Api exposing (ApiError, RequestConfig)
+import Api exposing (ApiError, RequestConfig)
 import Data.WorkflowInstance as WorkflowInstance exposing (WorkflowInstance)
 import Http
 import Json.Decode as Decode exposing (Decoder)

--- a/frontend/src/Api/WorkflowDefinition.elm
+++ b/frontend/src/Api/WorkflowDefinition.elm
@@ -27,7 +27,7 @@ BFF の `/api/v1/workflow-definitions` エンドポイントへのアクセス�
 
 -}
 
-import Api.Http as Api exposing (ApiError, RequestConfig)
+import Api exposing (ApiError, RequestConfig)
 import Data.WorkflowDefinition as WorkflowDefinition exposing (WorkflowDefinition)
 
 

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -8,8 +8,8 @@ TEA (The Elm Architecture) に基づく SPA のエントリーポイント。
 
 -}
 
+import Api exposing (ApiError)
 import Api.Auth as AuthApi
-import Api.Http exposing (ApiError)
 import Browser
 import Browser.Navigation as Nav
 import Html exposing (..)

--- a/frontend/src/Page/Home.elm
+++ b/frontend/src/Page/Home.elm
@@ -7,8 +7,8 @@ KPI 統計情報（承認待ち、申請中、本日完了）とクイックア�
 
 -}
 
+import Api exposing (ApiError)
 import Api.Dashboard as DashboardApi
-import Api.Http exposing (ApiError)
 import Data.Dashboard exposing (DashboardStats)
 import Html exposing (..)
 import Html.Attributes exposing (..)

--- a/frontend/src/Page/Task/Detail.elm
+++ b/frontend/src/Page/Task/Detail.elm
@@ -23,7 +23,7 @@ module Page.Task.Detail exposing
 
 -}
 
-import Api.Http exposing (ApiError(..))
+import Api exposing (ApiError(..))
 import Api.Task as TaskApi
 import Api.Workflow as WorkflowApi
 import Data.Task exposing (TaskDetail)

--- a/frontend/src/Page/Task/List.elm
+++ b/frontend/src/Page/Task/List.elm
@@ -20,7 +20,7 @@ module Page.Task.List exposing
 
 -}
 
-import Api.Http exposing (ApiError)
+import Api exposing (ApiError)
 import Api.Task as TaskApi
 import Data.Task exposing (TaskItem)
 import Data.WorkflowInstance as WorkflowInstance

--- a/frontend/src/Page/Workflow/Detail.elm
+++ b/frontend/src/Page/Workflow/Detail.elm
@@ -25,7 +25,7 @@ module Page.Workflow.Detail exposing
 
 -}
 
-import Api.Http exposing (ApiError(..))
+import Api exposing (ApiError(..))
 import Api.Workflow as WorkflowApi
 import Api.WorkflowDefinition as WorkflowDefinitionApi
 import Data.FormField exposing (FormField)

--- a/frontend/src/Page/Workflow/List.elm
+++ b/frontend/src/Page/Workflow/List.elm
@@ -25,7 +25,7 @@ module Page.Workflow.List exposing
 
 -}
 
-import Api.Http exposing (ApiError)
+import Api exposing (ApiError)
 import Api.Workflow as WorkflowApi
 import Data.WorkflowInstance as WorkflowInstance exposing (Status, WorkflowInstance)
 import Html exposing (..)

--- a/frontend/src/Page/Workflow/New.elm
+++ b/frontend/src/Page/Workflow/New.elm
@@ -27,7 +27,7 @@ module Page.Workflow.New exposing
 
 -}
 
-import Api.Http exposing (ApiError)
+import Api exposing (ApiError)
 import Api.Workflow as WorkflowApi
 import Api.WorkflowDefinition as WorkflowDefinitionApi
 import Data.WorkflowDefinition exposing (WorkflowDefinition)

--- a/frontend/src/Shared.elm
+++ b/frontend/src/Shared.elm
@@ -28,7 +28,7 @@ Shared は「グローバル状態」として Main.elm で保持し、
 
 -}
 
-import Api.Http exposing (RequestConfig)
+import Api exposing (RequestConfig)
 
 
 
@@ -116,7 +116,7 @@ extractTenantId =
 
 {-| API リクエスト設定に変換
 
-Api.Http モジュールの関数で使用する RequestConfig を生成。
+Api モジュールの関数で使用する RequestConfig を生成。
 
     shared
         |> Shared.toRequestConfig


### PR DESCRIPTION
## Issue

Closes #148

## Summary

`Api/Http.elm` を `Api.elm` にリネームし、モジュール階層を改善。
インフラ層（共通 HTTP ヘルパー）をルートモジュールとして配置し、API クライアント（`Api/Auth.elm` 等）との抽象レベルの混在を解消した。

## Changes

- `Api/Http.elm` → `Api.elm` にリネーム（`module Api.Http` → `module Api`）
- 13 ファイルの import を更新（`import Api.Http ...` → `import Api ...`）
- `ReviewConfig.elm` の ignoreErrorsForFiles パスを更新
- 4 つの実装解説ドキュメントのコード参照を更新
- doc コメント内の使用例を `import Api` 形式に更新

## Test plan

- [x] `just check-all` 通過（elm-review, elm-format, elm-test 81 tests, Rust 137 tests, clippy, build）
- [x] JSON 形状は変更なし（フロントエンドのモジュール構造のみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)