### PR TITLE
#146 Unify auth API paths under /api/v1

### DIFF
--- a/backend/apps/bff/src/handler/auth.rs
+++ b/backend/apps/bff/src/handler/auth.rs
@@ -4,9 +4,9 @@
 //!
 //! ## エンドポイント
 //!
-//! - `POST /auth/login` - ログイン
-//! - `POST /auth/logout` - ログアウト
-//! - `GET /auth/me` - 現在のユーザー情報を取得
+//! - `POST /api/v1/auth/login` - ログイン
+//! - `POST /api/v1/auth/logout` - ログアウト
+//! - `GET /api/v1/auth/me` - 現在のユーザー情報を取得
 //!
 //! 詳細: [08_AuthService設計.md](../../../../docs/03_詳細設計書/08_AuthService設計.md)
 
@@ -151,7 +151,7 @@ pub struct ErrorResponse {
 
 // --- ハンドラ ---
 
-/// POST /auth/login
+/// POST /api/v1/auth/login
 ///
 /// メール/パスワードでログインし、セッションを確立する。
 ///
@@ -293,7 +293,7 @@ where
    }
 }
 
-/// POST /auth/logout
+/// POST /api/v1/auth/logout
 ///
 /// セッションを無効化してログアウトする。
 pub async fn logout<C, A, S>(
@@ -339,7 +339,7 @@ where
    (jar, StatusCode::NO_CONTENT).into_response()
 }
 
-/// GET /auth/me
+/// GET /api/v1/auth/me
 ///
 /// 現在のユーザー情報と権限を取得する。
 pub async fn me<C, A, S>(
@@ -394,7 +394,7 @@ where
    }
 }
 
-/// GET /auth/csrf
+/// GET /api/v1/auth/csrf
 ///
 /// CSRF トークンを取得する。
 /// セッションが存在しない場合は新規作成し、存在する場合は既存のトークンを返す。
@@ -873,19 +873,19 @@ mod tests {
 
       Router::new()
          .route(
-            "/auth/login",
+            "/api/v1/auth/login",
             post(login::<StubCoreServiceClient, StubAuthServiceClient, StubSessionManager>),
          )
          .route(
-            "/auth/logout",
+            "/api/v1/auth/logout",
             post(logout::<StubCoreServiceClient, StubAuthServiceClient, StubSessionManager>),
          )
          .route(
-            "/auth/me",
+            "/api/v1/auth/me",
             get(me::<StubCoreServiceClient, StubAuthServiceClient, StubSessionManager>),
          )
          .route(
-            "/auth/csrf",
+            "/api/v1/auth/csrf",
             get(csrf::<StubCoreServiceClient, StubAuthServiceClient, StubSessionManager>),
          )
          .with_state(state)
@@ -911,7 +911,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::POST)
-         .uri("/auth/login")
+         .uri("/api/v1/auth/login")
          .header("content-type", "application/json")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -947,7 +947,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::POST)
-         .uri("/auth/login")
+         .uri("/api/v1/auth/login")
          .header("content-type", "application/json")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -985,7 +985,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::POST)
-         .uri("/auth/login")
+         .uri("/api/v1/auth/login")
          .header("content-type", "application/json")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -1014,7 +1014,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::POST)
-         .uri("/auth/login")
+         .uri("/api/v1/auth/login")
          .header("content-type", "application/json")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -1038,7 +1038,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::POST)
-         .uri("/auth/logout")
+         .uri("/api/v1/auth/logout")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .header("Cookie", "session_id=test-session-id")
          .body(Body::empty())
@@ -1071,7 +1071,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::GET)
-         .uri("/auth/me")
+         .uri("/api/v1/auth/me")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .header("Cookie", "session_id=test-session-id")
          .body(Body::empty())
@@ -1105,7 +1105,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::GET)
-         .uri("/auth/me")
+         .uri("/api/v1/auth/me")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          // Cookie なし
          .body(Body::empty())
@@ -1135,7 +1135,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::POST)
-         .uri("/auth/login")
+         .uri("/api/v1/auth/login")
          .header("content-type", "application/json")
          // X-Tenant-ID ヘッダーなし
          .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -1163,7 +1163,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::GET)
-         .uri("/auth/csrf")
+         .uri("/api/v1/auth/csrf")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          .header("Cookie", "session_id=test-session-id")
          .body(Body::empty())
@@ -1196,7 +1196,7 @@ mod tests {
 
       let request = Request::builder()
          .method(Method::GET)
-         .uri("/auth/csrf")
+         .uri("/api/v1/auth/csrf")
          .header("X-Tenant-ID", TEST_TENANT_ID)
          // Cookie なし
          .body(Body::empty())

--- a/backend/apps/bff/src/main.rs
+++ b/backend/apps/bff/src/main.rs
@@ -174,19 +174,19 @@ async fn main() -> anyhow::Result<()> {
    let app = Router::new()
       .route("/health", get(health_check))
       .route(
-         "/auth/login",
+         "/api/v1/auth/login",
          post(login::<CoreServiceClientImpl, AuthServiceClientImpl, RedisSessionManager>),
       )
       .route(
-         "/auth/logout",
+         "/api/v1/auth/logout",
          post(logout::<CoreServiceClientImpl, AuthServiceClientImpl, RedisSessionManager>),
       )
       .route(
-         "/auth/me",
+         "/api/v1/auth/me",
          get(me::<CoreServiceClientImpl, AuthServiceClientImpl, RedisSessionManager>),
       )
       .route(
-         "/auth/csrf",
+         "/api/v1/auth/csrf",
          get(csrf::<CoreServiceClientImpl, AuthServiceClientImpl, RedisSessionManager>),
       )
       .with_state(auth_state)

--- a/backend/apps/bff/src/middleware/csrf.rs
+++ b/backend/apps/bff/src/middleware/csrf.rs
@@ -26,7 +26,7 @@ const CSRF_HEADER: &str = "X-CSRF-Token";
 const SESSION_COOKIE_NAME: &str = "session_id";
 
 /// CSRF 検証をスキップするパス
-const CSRF_SKIP_PATHS: &[&str] = &["/auth/login", "/auth/csrf", "/health"];
+const CSRF_SKIP_PATHS: &[&str] = &["/api/v1/auth/login", "/api/v1/auth/csrf", "/health"];
 
 /// CSRF 検証の状態
 #[derive(Clone)]

--- a/docs/01_要件定義書/01_コア要件.md
+++ b/docs/01_要件定義書/01_コア要件.md
@@ -157,7 +157,7 @@ sequenceDiagram
 
     alt 標準ログイン（メール/パスワード）
         User->>SPA: ログイン情報入力
-        SPA->>BFF: POST /auth/login
+        SPA->>BFF: POST /api/v1/auth/login
         BFF->>Core: 認証リクエスト（内部）
         Core->>DB: ユーザー情報照会/検証
         DB-->>Core: ユーザー情報
@@ -166,11 +166,11 @@ sequenceDiagram
         SPA-->>User: ログイン完了
     else SSO（OIDC：認可コード + PKCE）
         User->>SPA: SSOログイン選択
-        SPA->>BFF: GET /auth/oidc/start
+        SPA->>BFF: GET /api/v1/auth/oidc/start
         BFF-->>SPA: IdPへリダイレクト（PKCE含む）
         SPA->>IdP: 認証リクエスト
         IdP-->>SPA: 認可コード（callback）
-        SPA->>BFF: GET /auth/oidc/callback?code=...
+        SPA->>BFF: GET /api/v1/auth/oidc/callback?code=...
         BFF->>IdP: トークン交換（サーバ側）
         IdP-->>BFF: ID/Access/Refresh（サーバ側保持）
         BFF-->>SPA: HTTPOnly セッションCookie設定
@@ -929,12 +929,12 @@ flowchart TB
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| POST | `/auth/login` | メール/パスワードログイン |
-| GET | `/auth/oidc/start` | OIDC 認証開始 |
-| GET | `/auth/oidc/callback` | OIDC コールバック |
-| POST | `/auth/logout` | ログアウト |
-| GET | `/auth/me` | 現在のユーザー情報取得 |
-| POST | `/auth/refresh` | セッション延長 |
+| POST | `/api/v1/auth/login` | メール/パスワードログイン |
+| GET | `/api/v1/auth/oidc/start` | OIDC 認証開始 |
+| GET | `/api/v1/auth/oidc/callback` | OIDC コールバック |
+| POST | `/api/v1/auth/logout` | ログアウト |
+| GET | `/api/v1/auth/me` | 現在のユーザー情報取得 |
+| POST | `/api/v1/auth/refresh` | セッション延長 |
 
 #### ワークフロー API
 

--- a/docs/03_詳細設計書/00_実装ロードマップ.md
+++ b/docs/03_詳細設計書/00_実装ロードマップ.md
@@ -236,9 +236,9 @@ erDiagram
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| POST | `/auth/login` | ログイン |
-| POST | `/auth/logout` | ログアウト |
-| GET | `/auth/me` | 現在のユーザー情報 |
+| POST | `/api/v1/auth/login` | ログイン |
+| POST | `/api/v1/auth/logout` | ログアウト |
+| GET | `/api/v1/auth/me` | 現在のユーザー情報 |
 | GET | `/api/v1/workflows` | ワークフロー一覧 |
 | POST | `/api/v1/workflows` | ワークフロー作成 |
 | GET | `/api/v1/workflows/{id}` | ワークフロー詳細 |

--- a/docs/03_詳細設計書/03_API設計.md
+++ b/docs/03_詳細設計書/03_API設計.md
@@ -20,7 +20,6 @@ graph LR
     end
 
     subgraph BFF["BFF (公開)"]
-        Auth["/auth/*"]
         API["/api/v1/*"]
     end
 
@@ -28,9 +27,7 @@ graph LR
         Internal["内部 API"]
     end
 
-    SPA --> Auth
     SPA --> API
-    Auth --> Internal
     API --> Internal
 ```
 
@@ -67,7 +64,7 @@ API 設計の一般的なパターンはナレッジベースを参照。
 
 ## 認証 API
 
-### POST /auth/login
+### POST /api/v1/auth/login
 
 メール/パスワードでログインする。
 
@@ -111,7 +108,7 @@ Set-Cookie: session_id=xxx; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=2880
 
 ---
 
-### POST /auth/logout
+### POST /api/v1/auth/logout
 
 ログアウトする。
 
@@ -126,7 +123,7 @@ Set-Cookie: session_id=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0
 
 ---
 
-### GET /auth/me
+### GET /api/v1/auth/me
 
 現在のユーザー情報を取得する。
 
@@ -157,7 +154,7 @@ Set-Cookie: session_id=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0
 
 ---
 
-### GET /auth/csrf
+### GET /api/v1/auth/csrf
 
 CSRF トークンを取得する。
 
@@ -694,7 +691,7 @@ sequenceDiagram
     participant DB as PostgreSQL
     participant Redis as Redis
 
-    Browser->>BFF: POST /auth/login
+    Browser->>BFF: POST /api/v1/auth/login
     BFF->>Core: 認証リクエスト
     Core->>DB: ユーザー検証
     DB-->>Core: ユーザー情報
@@ -702,7 +699,7 @@ sequenceDiagram
     BFF->>Redis: セッション保存
     BFF-->>Browser: Set-Cookie: session_id
 
-    Browser->>BFF: GET /auth/csrf
+    Browser->>BFF: GET /api/v1/auth/csrf
     BFF->>Redis: CSRF トークン生成・保存
     BFF-->>Browser: CSRF トークン
 

--- a/docs/03_詳細設計書/07_認証機能設計.md
+++ b/docs/03_詳細設計書/07_認証機能設計.md
@@ -37,7 +37,7 @@ sequenceDiagram
     participant DB as PostgreSQL
     participant Redis as Redis
 
-    Browser->>BFF: POST /auth/login (email, password)
+    Browser->>BFF: POST /api/v1/auth/login (email, password)
     BFF->>Core: POST /internal/auth/verify
     Core->>DB: SELECT user WHERE email = ?
     DB-->>Core: User + password_hash
@@ -48,7 +48,7 @@ sequenceDiagram
 
     Note over Browser,BFF: 以降のリクエストは Cookie で認証
 
-    Browser->>BFF: GET /auth/me (Cookie)
+    Browser->>BFF: GET /api/v1/auth/me (Cookie)
     BFF->>Redis: GET session:{tenant_id}:{session_id}
     Redis-->>BFF: SessionData
     BFF->>Core: GET /internal/users/{user_id}
@@ -56,7 +56,7 @@ sequenceDiagram
     Core-->>BFF: UserWithPermissions
     BFF-->>Browser: UserResponse
 
-    Browser->>BFF: POST /auth/logout (Cookie)
+    Browser->>BFF: POST /api/v1/auth/logout (Cookie)
     BFF->>Redis: DEL session:{tenant_id}:{session_id}
     BFF-->>Browser: Set-Cookie: session_id= (Max-Age=0)
 ```
@@ -76,7 +76,7 @@ sequenceDiagram
 
 ### BFF 公開 API
 
-#### POST /auth/login
+#### POST /api/v1/auth/login
 
 メール/パスワードでログインし、セッションを確立する。
 
@@ -124,7 +124,7 @@ Set-Cookie: session_id=xxx; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=2880
 
 ---
 
-#### POST /auth/logout
+#### POST /api/v1/auth/logout
 
 セッションを無効化してログアウトする。
 
@@ -139,7 +139,7 @@ Set-Cookie: session_id=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0
 
 ---
 
-#### GET /auth/me
+#### GET /api/v1/auth/me
 
 現在のユーザー情報と権限を取得する。
 
@@ -172,7 +172,7 @@ Set-Cookie: session_id=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0
 
 ---
 
-#### GET /auth/csrf
+#### GET /api/v1/auth/csrf
 
 CSRF トークンを取得する。
 
@@ -344,7 +344,7 @@ flowchart TB
 ### Double Submit Cookie パターン
 
 1. ログイン成功時、CSRF トークンを生成して Redis に保存
-2. `GET /auth/csrf` でトークンをクライアントに返す
+2. `GET /api/v1/auth/csrf` でトークンをクライアントに返す
 3. クライアントは状態変更リクエスト時に `X-CSRF-Token` ヘッダーにトークンを付与
 4. BFF でトークンを検証
 
@@ -589,10 +589,10 @@ pub trait SessionManager: Send + Sync {
 | ログイン失敗（パスワード不一致） | 不正なパスワードで 401 |
 | ログイン失敗（メール不存在） | 存在しないメールで 401 |
 | ログイン失敗（非アクティブユーザー） | 非アクティブユーザーで 401 |
-| ユーザー情報取得 | Cookie でログイン後、/auth/me でユーザー情報取得 |
-| ログアウト | ログイン → ログアウト → /auth/me で 401 |
+| ユーザー情報取得 | Cookie でログイン後、/api/v1/auth/me でユーザー情報取得 |
+| ログアウト | ログイン → ログアウト → /api/v1/auth/me で 401 |
 | CSRF トークン生成 | ログイン成功時に CSRF トークンが Redis に生成される |
-| CSRF トークン取得 | GET /auth/csrf でトークンを取得できる |
+| CSRF トークン取得 | GET /api/v1/auth/csrf でトークンを取得できる |
 | CSRF 検証成功 | 正しいトークンで POST リクエストが成功 |
 | CSRF 検証失敗（トークンなし） | トークンなしで 403 |
 | CSRF 検証失敗（不正トークン） | 不正なトークンで 403 |

--- a/docs/03_詳細設計書/08_AuthService設計.md
+++ b/docs/03_詳細設計書/08_AuthService設計.md
@@ -300,7 +300,7 @@ Auth Service は内部エンドポイントのみを提供し、BFF からのみ
 
 ### BFF（変更点）
 
-現行の `/auth/login` フローを変更し、Core Service と Auth Service の両方を呼び出す。
+現行の `/api/v1/auth/login` フローを変更し、Core Service と Auth Service の両方を呼び出す。
 
 #### 変更後のログインフロー
 
@@ -313,7 +313,7 @@ sequenceDiagram
     participant Auth as Auth Service
     participant Redis as Redis
 
-    Browser->>BFF: POST /auth/login (email, password)
+    Browser->>BFF: POST /api/v1/auth/login (email, password)
     BFF->>Core: GET /internal/users/by-email?email=xxx&tenant_id=yyy
     Core-->>BFF: User or 404
     alt ユーザー存在

--- a/docs/03_詳細設計書/10_ワークフロー申請フォームUI設計.md
+++ b/docs/03_詳細設計書/10_ワークフロー申請フォームUI設計.md
@@ -198,10 +198,10 @@ sequenceDiagram
 
     Browser->>Elm: init (flags)
     Note over Elm: apiBaseUrl を flags から取得
-    Elm->>BFF: GET /auth/me
+    Elm->>BFF: GET /api/v1/auth/me
     BFF-->>Elm: User 情報 or 401
     alt 認証済み
-        Elm->>BFF: GET /auth/csrf
+        Elm->>BFF: GET /api/v1/auth/csrf
         BFF-->>Elm: CSRF トークン
         Elm->>Elm: Shared 初期化完了
     else 未認証

--- a/frontend/src/Api/Auth.elm
+++ b/frontend/src/Api/Auth.elm
@@ -2,7 +2,7 @@ module Api.Auth exposing (getCsrfToken, getMe)
 
 {-| 認証 API クライアント
 
-BFF の `/auth` エンドポイントへのアクセスを提供。
+BFF の `/api/v1/auth` エンドポイントへのアクセスを提供。
 
 
 ## 使用例
@@ -30,7 +30,7 @@ import Shared exposing (User)
 
 {-| CSRF トークンを取得
 
-`GET /auth/csrf`
+`GET /api/v1/auth/csrf`
 
 状態変更リクエスト（POST/PUT/DELETE）で必要な CSRF トークンを取得する。
 セッションが存在しない場合は 401 Unauthorized が返される。
@@ -44,7 +44,7 @@ getCsrfToken :
 getCsrfToken { config, toMsg } =
     Api.get
         { config = config
-        , url = "/auth/csrf"
+        , url = "/api/v1/auth/csrf"
         , decoder = csrfTokenDecoder
         , toMsg = toMsg
         }
@@ -52,7 +52,7 @@ getCsrfToken { config, toMsg } =
 
 {-| 現在のユーザー情報を取得
 
-`GET /auth/me`
+`GET /api/v1/auth/me`
 
 セッションが有効な場合、ユーザー情報（ID、メール、名前、ロール）を返す。
 未認証の場合は 401 Unauthorized が返される。
@@ -66,7 +66,7 @@ getMe :
 getMe { config, toMsg } =
     Api.get
         { config = config
-        , url = "/auth/me"
+        , url = "/api/v1/auth/me"
         , decoder = userDecoder
         , toMsg = toMsg
         }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -22,10 +22,6 @@ export default defineConfig({
         target: `http://localhost:${process.env.BFF_PORT}`,
         changeOrigin: true,
       },
-      "/auth": {
-        target: `http://localhost:${process.env.BFF_PORT}`,
-        changeOrigin: true,
-      },
     },
   },
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -45,7 +45,7 @@ paths:
   # ============================================================
   # 認証 API
   # ============================================================
-  /auth/login:
+  /api/v1/auth/login:
     post:
       tags:
         - auth
@@ -96,7 +96,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationError'
 
-  /auth/logout:
+  /api/v1/auth/logout:
     post:
       tags:
         - auth
@@ -120,7 +120,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /auth/me:
+  /api/v1/auth/me:
     get:
       tags:
         - auth
@@ -139,7 +139,7 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
-  /auth/csrf:
+  /api/v1/auth/csrf:
     get:
       tags:
         - auth
@@ -769,7 +769,7 @@ components:
       name: X-CSRF-Token
       in: header
       required: true
-      description: CSRF トークン（/auth/csrf で取得）
+      description: CSRF トークン（/api/v1/auth/csrf で取得）
       schema:
         type: string
       example: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"

--- a/tests/api/hurl/auth/csrf.hurl
+++ b/tests/api/hurl/auth/csrf.hurl
@@ -1,5 +1,5 @@
 # CSRF トークン取得 API テスト（認証済み）
-# GET /auth/csrf
+# GET /api/v1/auth/csrf
 #
 # 状態変更リクエスト（POST/PUT/PATCH/DELETE）に必要な CSRF トークンを取得する。
 
@@ -7,7 +7,7 @@
 # 前提: ログインしてセッションを取得
 # =============================================================================
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -24,10 +24,10 @@ session_cookie: cookie "session_id"
 # 正常系: 認証済みユーザーは CSRF トークンを取得できる
 # =============================================================================
 # Given: ログイン済みのセッションがある
-# When: GET /auth/csrf にセッション Cookie を送信する
+# When: GET /api/v1/auth/csrf にセッション Cookie を送信する
 # Then: 64文字の16進数トークンが返される
 
-GET {{bff_url}}/auth/csrf
+GET {{bff_url}}/api/v1/auth/csrf
 X-Tenant-ID: {{tenant_id}}
 Cookie: session_id={{session_cookie}}
 

--- a/tests/api/hurl/auth/csrf_unauthorized.hurl
+++ b/tests/api/hurl/auth/csrf_unauthorized.hurl
@@ -1,5 +1,5 @@
 # CSRF トークン取得 API テスト（未認証）
-# GET /auth/csrf
+# GET /api/v1/auth/csrf
 #
 # 未認証のリクエストが適切に拒否されることを検証する。
 
@@ -7,10 +7,10 @@
 # 異常系: 未認証のリクエストは拒否される
 # =============================================================================
 # Given: ログインしていない（セッション Cookie なし）
-# When: GET /auth/csrf にリクエストする
+# When: GET /api/v1/auth/csrf にリクエストする
 # Then: 401 Unauthorized が返される
 
-GET {{bff_url}}/auth/csrf
+GET {{bff_url}}/api/v1/auth/csrf
 X-Tenant-ID: {{tenant_id}}
 
 HTTP 401

--- a/tests/api/hurl/auth/login.hurl
+++ b/tests/api/hurl/auth/login.hurl
@@ -1,5 +1,5 @@
 # ログイン API テスト
-# POST /auth/login
+# POST /api/v1/auth/login
 #
 # ログイン機能の E2E テスト。BFF → Core API → Auth Service の連携を検証する。
 
@@ -10,7 +10,7 @@
 # When: 正しいメールアドレスとパスワードでログインする
 # Then: ユーザー情報とセッション Cookie が返される
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -38,7 +38,7 @@ header "Set-Cookie" contains "HttpOnly"
 # When: 間違ったパスワードでログインする
 # Then: 401 Unauthorized が返される（セキュリティのためユーザー存在は漏らさない）
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -60,7 +60,7 @@ jsonpath "$.status" == 401
 # When: ログインを試みる
 # Then: 401 Unauthorized が返される（タイミング攻撃対策として同じレスポンス）
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -82,7 +82,7 @@ jsonpath "$.status" == 401
 # When: X-Tenant-ID ヘッダーなしでログインする
 # Then: 400 Bad Request が返される
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 Content-Type: application/json
 {
     "email": "{{admin_email}}",

--- a/tests/api/hurl/auth/logout.hurl
+++ b/tests/api/hurl/auth/logout.hurl
@@ -1,5 +1,5 @@
 # ログアウト API テスト
-# POST /auth/logout
+# POST /api/v1/auth/logout
 #
 # ログアウト機能とセッション無効化を検証する。
 
@@ -7,7 +7,7 @@
 # 前提: ログインしてセッションを取得
 # =============================================================================
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -24,7 +24,7 @@ session_cookie: cookie "session_id"
 # 前提: CSRF トークンを取得（状態変更リクエストに必要）
 # =============================================================================
 
-GET {{bff_url}}/auth/csrf
+GET {{bff_url}}/api/v1/auth/csrf
 X-Tenant-ID: {{tenant_id}}
 Cookie: session_id={{session_cookie}}
 
@@ -37,10 +37,10 @@ csrf_token: jsonpath "$.data.token"
 # 正常系: ログアウトでセッションが無効化される
 # =============================================================================
 # Given: ログイン済みのセッションと CSRF トークンがある
-# When: POST /auth/logout に CSRF トークンを付けてリクエストする
+# When: POST /api/v1/auth/logout に CSRF トークンを付けてリクエストする
 # Then: 204 No Content が返され、セッション Cookie がクリアされる
 
-POST {{bff_url}}/auth/logout
+POST {{bff_url}}/api/v1/auth/logout
 X-Tenant-ID: {{tenant_id}}
 X-CSRF-Token: {{csrf_token}}
 Cookie: session_id={{session_cookie}}
@@ -56,10 +56,10 @@ header "Set-Cookie" contains "Max-Age=0"
 # 確認: ログアウト後は認証が必要なエンドポイントにアクセスできない
 # =============================================================================
 # Given: ログアウト済み（セッションが無効化された）
-# When: 古いセッション Cookie で /auth/me にアクセスする
+# When: 古いセッション Cookie で /api/v1/auth/me にアクセスする
 # Then: 401 Unauthorized が返される（セッションが無効なため）
 
-GET {{bff_url}}/auth/me
+GET {{bff_url}}/api/v1/auth/me
 X-Tenant-ID: {{tenant_id}}
 Cookie: session_id={{session_cookie}}
 

--- a/tests/api/hurl/auth/me.hurl
+++ b/tests/api/hurl/auth/me.hurl
@@ -1,5 +1,5 @@
 # ユーザー情報取得 API テスト（認証済み）
-# GET /auth/me
+# GET /api/v1/auth/me
 #
 # ログイン済みユーザーが自分の情報を取得できることを検証する。
 
@@ -7,7 +7,7 @@
 # 前提: ログインしてセッションを取得
 # =============================================================================
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -24,10 +24,10 @@ session_cookie: cookie "session_id"
 # 正常系: 認証済みユーザーは自分の情報を取得できる
 # =============================================================================
 # Given: ログイン済みのセッションがある
-# When: GET /auth/me にセッション Cookie を送信する
+# When: GET /api/v1/auth/me にセッション Cookie を送信する
 # Then: ユーザー情報（ID、メール、名前、ロール、権限）が返される
 
-GET {{bff_url}}/auth/me
+GET {{bff_url}}/api/v1/auth/me
 X-Tenant-ID: {{tenant_id}}
 Cookie: session_id={{session_cookie}}
 

--- a/tests/api/hurl/auth/me_unauthorized.hurl
+++ b/tests/api/hurl/auth/me_unauthorized.hurl
@@ -1,5 +1,5 @@
 # ユーザー情報取得 API テスト（未認証）
-# GET /auth/me
+# GET /api/v1/auth/me
 #
 # 未認証のリクエストが適切に拒否されることを検証する。
 
@@ -7,10 +7,10 @@
 # 異常系: 未認証のリクエストは拒否される
 # =============================================================================
 # Given: ログインしていない（セッション Cookie なし）
-# When: GET /auth/me にリクエストする
+# When: GET /api/v1/auth/me にリクエストする
 # Then: 401 Unauthorized が返される
 
-GET {{bff_url}}/auth/me
+GET {{bff_url}}/api/v1/auth/me
 X-Tenant-ID: {{tenant_id}}
 
 HTTP 401

--- a/tests/api/hurl/workflow/create_workflow.hurl
+++ b/tests/api/hurl/workflow/create_workflow.hurl
@@ -7,7 +7,7 @@
 # 前提: ログインしてセッションを確立
 # =============================================================================
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -20,7 +20,7 @@ HTTP 200
 session_cookie: cookie "session_id"
 
 # CSRF トークンを取得
-GET {{bff_url}}/auth/csrf
+GET {{bff_url}}/api/v1/auth/csrf
 X-Tenant-ID: {{tenant_id}}
 Cookie: session_id={{session_cookie}}
 

--- a/tests/api/hurl/workflow/submit_workflow.hurl
+++ b/tests/api/hurl/workflow/submit_workflow.hurl
@@ -7,7 +7,7 @@
 # 前提: ログインしてワークフローを作成
 # =============================================================================
 
-POST {{bff_url}}/auth/login
+POST {{bff_url}}/api/v1/auth/login
 X-Tenant-ID: {{tenant_id}}
 Content-Type: application/json
 {
@@ -20,7 +20,7 @@ HTTP 200
 session_cookie: cookie "session_id"
 
 # CSRF トークンを取得
-GET {{bff_url}}/auth/csrf
+GET {{bff_url}}/api/v1/auth/csrf
 X-Tenant-ID: {{tenant_id}}
 Cookie: session_id={{session_cookie}}
 


### PR DESCRIPTION
## Issue

Closes #146

## Summary

すべての認証エンドポイントを `/auth/*` から `/api/v1/auth/*` に移行し、API パス設計を統一する。

## Changes

- Backend: ルート定義、CSRF スキップパス、ハンドラのドキュメント、テスト URI を更新
- Frontend: API URL（Auth.elm）を更新、vite.config.js の `/auth` プロキシエントリを削除
- OpenAPI: パスキーと CSRF 説明を更新
- Hurl E2E テスト: 全認証パス参照を更新
- ドキュメント: Living docs（要件定義書、API 設計書、認証機能設計書、AuthService 設計書）を更新

### 変更しないもの

- `/internal/auth/*`（Auth Service 内部 API）
- `/health`（インフラ用エンドポイント）
- 歴史的ドキュメント（ADR、セッションログ等）

## Test plan

- `just check-all` で全テスト（lint + unit + integration）がパスすること
- `grep -rn '"/auth/' --include='*.rs' --include='*.elm' --include='*.js' --include='*.yaml'` でソースコードに旧パスが残っていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)