### PR TITLE
#200 Fix UTC timezone display

### DIFF
--- a/frontend/elm.json
+++ b/frontend/elm.json
@@ -13,12 +13,14 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/svg": "1.0.1",
-            "elm/url": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/time": "1.0.0",
+            "elm/parser": "1.1.0",
             "elm/virtual-dom": "1.0.3"
         }
     },

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -57,6 +57,7 @@ main =
 type alias Flags =
     { apiBaseUrl : String
     , timestamp : Int
+    , timezoneOffsetMinutes : Int
     }
 
 
@@ -108,7 +109,10 @@ init flags url key =
             Route.fromUrl url
 
         shared =
-            Shared.init { apiBaseUrl = flags.apiBaseUrl }
+            Shared.init
+                { apiBaseUrl = flags.apiBaseUrl
+                , timezoneOffsetMinutes = flags.timezoneOffsetMinutes
+                }
 
         ( page, pageCmd ) =
             initPage route shared

--- a/frontend/src/Page/Task/Detail.elm
+++ b/frontend/src/Page/Task/Detail.elm
@@ -47,6 +47,7 @@ import Json.Decode as Decode
 import RemoteData exposing (RemoteData(..))
 import Route
 import Shared exposing (Shared)
+import Time
 import Util.DateFormat as DateFormat
 import Util.KeyEvent as KeyEvent
 
@@ -371,7 +372,7 @@ viewTaskDetail taskDetail model =
         , viewWorkflowStatus taskDetail.workflow
         , viewApprovalSection taskDetail.step model
         , viewSteps taskDetail.workflow
-        , viewBasicInfo taskDetail.workflow
+        , viewBasicInfo (Shared.zone model.shared) taskDetail.workflow
         , viewFormData taskDetail.workflow
         ]
 
@@ -517,19 +518,19 @@ viewConfirmDialog maybePending =
 -- WORKFLOW INFO VIEWS
 
 
-viewBasicInfo : WorkflowInstance -> Html Msg
-viewBasicInfo workflow =
+viewBasicInfo : Time.Zone -> WorkflowInstance -> Html Msg
+viewBasicInfo zone workflow =
     div []
         [ h2 [ class "mb-3 text-lg font-semibold text-secondary-900" ] [ text "基本情報" ]
         , dl [ class "grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm" ]
             [ dt [ class "text-secondary-500" ] [ text "申請者" ]
             , dd [ class "text-secondary-900" ] [ text workflow.initiatedBy.name ]
             , dt [ class "text-secondary-500" ] [ text "申請日" ]
-            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatMaybeDateTime workflow.submittedAt) ]
+            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatMaybeDateTime zone workflow.submittedAt) ]
             , dt [ class "text-secondary-500" ] [ text "作成日" ]
-            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime workflow.createdAt) ]
+            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime zone workflow.createdAt) ]
             , dt [ class "text-secondary-500" ] [ text "更新日" ]
-            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime workflow.updatedAt) ]
+            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime zone workflow.updatedAt) ]
             ]
         ]
 

--- a/frontend/src/Page/Task/List.elm
+++ b/frontend/src/Page/Task/List.elm
@@ -31,6 +31,7 @@ import Html.Events exposing (onClick)
 import RemoteData exposing (RemoteData(..))
 import Route
 import Shared exposing (Shared)
+import Time
 import Util.DateFormat as DateFormat
 
 
@@ -138,7 +139,7 @@ viewContent model =
             viewError
 
         Success tasks ->
-            viewTaskList tasks
+            viewTaskList (Shared.zone model.shared) tasks
 
 
 viewError : Html Msg
@@ -150,8 +151,8 @@ viewError =
         ]
 
 
-viewTaskList : List TaskItem -> Html Msg
-viewTaskList tasks =
+viewTaskList : Time.Zone -> List TaskItem -> Html Msg
+viewTaskList zone tasks =
     if List.isEmpty tasks then
         div [ class "py-12 text-center" ]
             [ p [ class "text-secondary-500" ] [ text "承認待ちのタスクはありません" ]
@@ -160,13 +161,13 @@ viewTaskList tasks =
 
     else
         div []
-            [ div [ class "overflow-x-auto" ] [ viewTaskTable tasks ]
+            [ div [ class "overflow-x-auto" ] [ viewTaskTable zone tasks ]
             , viewCount (List.length tasks)
             ]
 
 
-viewTaskTable : List TaskItem -> Html Msg
-viewTaskTable tasks =
+viewTaskTable : Time.Zone -> List TaskItem -> Html Msg
+viewTaskTable zone tasks =
     table [ class "w-full" ]
         [ thead [ class "border-b border-secondary-100" ]
             [ tr []
@@ -178,12 +179,12 @@ viewTaskTable tasks =
                 ]
             ]
         , tbody []
-            (List.map viewTaskRow tasks)
+            (List.map (viewTaskRow zone) tasks)
         ]
 
 
-viewTaskRow : TaskItem -> Html Msg
-viewTaskRow task =
+viewTaskRow : Time.Zone -> TaskItem -> Html Msg
+viewTaskRow zone task =
     tr [ class "border-b border-secondary-100" ]
         [ td [ class "px-4 py-3" ]
             [ a [ href (Route.toString (Route.TaskDetail task.id)), class "text-primary-600 hover:text-primary-700 hover:underline" ]
@@ -194,8 +195,8 @@ viewTaskRow task =
             [ span [ class ("inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium " ++ WorkflowInstance.stepStatusToCssClass task.status) ]
                 [ text (WorkflowInstance.stepStatusToJapanese task.status) ]
             ]
-        , td [ class "px-4 py-3" ] [ text (DateFormat.formatMaybeDate task.dueDate) ]
-        , td [ class "px-4 py-3" ] [ text (DateFormat.formatMaybeDate task.startedAt) ]
+        , td [ class "px-4 py-3" ] [ text (DateFormat.formatMaybeDate zone task.dueDate) ]
+        , td [ class "px-4 py-3" ] [ text (DateFormat.formatMaybeDate zone task.startedAt) ]
         ]
 
 

--- a/frontend/src/Page/Workflow/Detail.elm
+++ b/frontend/src/Page/Workflow/Detail.elm
@@ -46,6 +46,7 @@ import Json.Decode as Decode
 import RemoteData exposing (RemoteData(..))
 import Route
 import Shared exposing (Shared)
+import Time
 import Util.DateFormat as DateFormat
 import Util.KeyEvent as KeyEvent
 
@@ -358,7 +359,7 @@ viewWorkflowDetail workflow maybeDefinition comment isSubmitting shared =
         , viewStatus workflow
         , viewApprovalSection workflow comment isSubmitting shared
         , viewSteps workflow
-        , viewBasicInfo workflow
+        , viewBasicInfo (Shared.zone shared) workflow
         , viewFormData workflow maybeDefinition
         ]
 
@@ -377,19 +378,19 @@ viewStatus workflow =
         ]
 
 
-viewBasicInfo : WorkflowInstance -> Html Msg
-viewBasicInfo workflow =
+viewBasicInfo : Time.Zone -> WorkflowInstance -> Html Msg
+viewBasicInfo zone workflow =
     div []
         [ h2 [ class "mb-3 text-lg font-semibold text-secondary-900" ] [ text "基本情報" ]
         , dl [ class "grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm" ]
             [ dt [ class "text-secondary-500" ] [ text "申請者" ]
             , dd [ class "text-secondary-900" ] [ text workflow.initiatedBy.name ]
             , dt [ class "text-secondary-500" ] [ text "申請日" ]
-            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatMaybeDateTime workflow.submittedAt) ]
+            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatMaybeDateTime zone workflow.submittedAt) ]
             , dt [ class "text-secondary-500" ] [ text "作成日" ]
-            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime workflow.createdAt) ]
+            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime zone workflow.createdAt) ]
             , dt [ class "text-secondary-500" ] [ text "更新日" ]
-            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime workflow.updatedAt) ]
+            , dd [ class "text-secondary-900" ] [ text (DateFormat.formatDateTime zone workflow.updatedAt) ]
             ]
         ]
 

--- a/frontend/src/Page/Workflow/List.elm
+++ b/frontend/src/Page/Workflow/List.elm
@@ -35,6 +35,7 @@ import Html.Events exposing (onClick, onInput)
 import RemoteData exposing (RemoteData(..))
 import Route
 import Shared exposing (Shared)
+import Time
 import Util.DateFormat as DateFormat
 
 
@@ -160,7 +161,7 @@ viewContent model =
             viewError
 
         Success workflows ->
-            viewWorkflowList model.statusFilter workflows
+            viewWorkflowList (Shared.zone model.shared) model.statusFilter workflows
 
 
 viewError : Html Msg
@@ -172,8 +173,8 @@ viewError =
         ]
 
 
-viewWorkflowList : Maybe Status -> List WorkflowInstance -> Html Msg
-viewWorkflowList statusFilter workflows =
+viewWorkflowList : Time.Zone -> Maybe Status -> List WorkflowInstance -> Html Msg
+viewWorkflowList zone statusFilter workflows =
     let
         filteredWorkflows =
             case statusFilter of
@@ -194,7 +195,7 @@ viewWorkflowList statusFilter workflows =
 
           else
             div []
-                [ div [ class "overflow-x-auto" ] [ viewWorkflowTable filteredWorkflows ]
+                [ div [ class "overflow-x-auto" ] [ viewWorkflowTable zone filteredWorkflows ]
                 , viewCount (List.length filteredWorkflows)
                 ]
         ]
@@ -251,8 +252,8 @@ statusFromFilterValue str =
         WorkflowInstance.statusFromString str
 
 
-viewWorkflowTable : List WorkflowInstance -> Html Msg
-viewWorkflowTable workflows =
+viewWorkflowTable : Time.Zone -> List WorkflowInstance -> Html Msg
+viewWorkflowTable zone workflows =
     table [ class "w-full border-collapse" ]
         [ thead [ class "border-b border-secondary-100" ]
             [ tr []
@@ -262,12 +263,12 @@ viewWorkflowTable workflows =
                 ]
             ]
         , tbody []
-            (List.map viewWorkflowRow workflows)
+            (List.map (viewWorkflowRow zone) workflows)
         ]
 
 
-viewWorkflowRow : WorkflowInstance -> Html Msg
-viewWorkflowRow workflow =
+viewWorkflowRow : Time.Zone -> WorkflowInstance -> Html Msg
+viewWorkflowRow zone workflow =
     tr [ class "border-b border-secondary-100" ]
         [ td [ class "px-4 py-3" ]
             [ a [ href (Route.toString (Route.WorkflowDetail workflow.id)), class "text-primary-600 hover:text-primary-700 hover:underline" ]
@@ -277,7 +278,7 @@ viewWorkflowRow workflow =
             [ span [ class ("inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium " ++ WorkflowInstance.statusToCssClass workflow.status) ]
                 [ text (WorkflowInstance.statusToJapanese workflow.status) ]
             ]
-        , td [ class "px-4 py-3" ] [ text (DateFormat.formatDate workflow.createdAt) ]
+        , td [ class "px-4 py-3" ] [ text (DateFormat.formatDate zone workflow.createdAt) ]
         ]
 
 

--- a/frontend/src/Shared.elm
+++ b/frontend/src/Shared.elm
@@ -6,6 +6,7 @@ module Shared exposing
     , toRequestConfig
     , withCsrfToken
     , withUser
+    , zone
     )
 
 {-| 共有状態モジュール
@@ -29,6 +30,7 @@ Shared は「グローバル状態」として Main.elm で保持し、
 -}
 
 import Api exposing (RequestConfig)
+import Time
 
 
 
@@ -60,6 +62,7 @@ type alias Shared =
     , tenantId : String
     , csrfToken : Maybe String
     , apiBaseUrl : String
+    , timeZone : Time.Zone
     }
 
 
@@ -72,13 +75,17 @@ type alias Shared =
 開発環境では仮のテナント ID を使用。
 本番環境では GET /auth/me でテナント情報を取得する。
 
+timezoneOffsetMinutes: JavaScript の getTimezoneOffset() を反転した値。
+JST なら 540（= +9 \* 60）。
+
 -}
-init : { apiBaseUrl : String } -> Shared
-init { apiBaseUrl } =
+init : { apiBaseUrl : String, timezoneOffsetMinutes : Int } -> Shared
+init { apiBaseUrl, timezoneOffsetMinutes } =
     { user = Nothing
     , tenantId = "00000000-0000-0000-0000-000000000001" -- 開発用テナント
     , csrfToken = Nothing
     , apiBaseUrl = apiBaseUrl
+    , timeZone = Time.customZone timezoneOffsetMinutes []
     }
 
 
@@ -139,3 +146,13 @@ toRequestConfig shared =
 getUserId : Shared -> Maybe String
 getUserId shared =
     shared.user |> Maybe.map .id
+
+
+{-| タイムゾーンを取得
+
+日付・時刻のフォーマットに使用する。
+
+-}
+zone : Shared -> Time.Zone
+zone shared =
+    shared.timeZone

--- a/frontend/src/Util/DateFormat.elm
+++ b/frontend/src/Util/DateFormat.elm
@@ -7,74 +7,182 @@ module Util.DateFormat exposing
 
 {-| 日付フォーマットユーティリティ
 
-ISO 8601 日時文字列を UI 表示用にフォーマットする純粋関数を提供する。
+ISO 8601 日時文字列をタイムゾーン変換し、UI 表示用にフォーマットする。
+バックエンドから UTC（RFC 3339）で返される日時を、ブラウザのローカルタイムゾーンに変換して表示する。
 
 
 ## 使用例
 
+    import Time
     import Util.DateFormat as DateFormat
 
-    -- 日付のみ
-    DateFormat.formatDate "2026-01-15T10:30:00Z"
+    -- 日付のみ（JST で表示）
+    DateFormat.formatDate jst "2026-01-15T10:30:00Z"
     --> "2026-01-15"
 
-    -- 日付と時刻
-    DateFormat.formatDateTime "2026-01-15T10:30:00Z"
-    --> "2026-01-15 10:30"
+    -- 日付と時刻（JST で表示、+9時間）
+    DateFormat.formatDateTime jst "2026-01-15T10:30:00Z"
+    --> "2026-01-15 19:30"
 
     -- Maybe 対応
-    DateFormat.formatMaybeDate Nothing
+    DateFormat.formatMaybeDate jst Nothing
     --> "-"
 
 -}
 
+import Iso8601
+import Time
 
-{-| ISO 8601 日時文字列から日付部分を抽出
 
-    formatDate "2026-01-15T10:30:00Z" --> "2026-01-15"
+{-| ISO 8601 日時文字列からタイムゾーン変換した日付を取得
+
+    formatDate jst "2026-01-15T10:30:00Z" --> "2026-01-15"
 
 -}
-formatDate : String -> String
-formatDate isoString =
-    String.left 10 isoString
+formatDate : Time.Zone -> String -> String
+formatDate zone isoString =
+    case Iso8601.toTime isoString of
+        Ok posix ->
+            formatPosixDate zone posix
+
+        Err _ ->
+            isoString
 
 
-{-| Maybe な日時文字列から日付部分を抽出
+{-| Maybe な日時文字列からタイムゾーン変換した日付を取得
 
 Nothing の場合は "-" を返す。
 
 -}
-formatMaybeDate : Maybe String -> String
-formatMaybeDate maybeDate =
+formatMaybeDate : Time.Zone -> Maybe String -> String
+formatMaybeDate zone maybeDate =
     case maybeDate of
         Just isoString ->
-            formatDate isoString
+            formatDate zone isoString
 
         Nothing ->
             "-"
 
 
-{-| ISO 8601 日時文字列から日付と時刻（分まで）を抽出
+{-| ISO 8601 日時文字列からタイムゾーン変換した日時を取得
 
-    formatDateTime "2026-01-15T10:30:00Z" --> "2026-01-15 10:30"
+    formatDateTime jst "2026-01-15T10:30:00Z" --> "2026-01-15 19:30"
 
 -}
-formatDateTime : String -> String
-formatDateTime isoString =
-    String.left 16 isoString
-        |> String.replace "T" " "
+formatDateTime : Time.Zone -> String -> String
+formatDateTime zone isoString =
+    case Iso8601.toTime isoString of
+        Ok posix ->
+            formatPosixDate zone posix
+                ++ " "
+                ++ formatPosixTime zone posix
+
+        Err _ ->
+            isoString
 
 
-{-| Maybe な日時文字列から日付と時刻を抽出
+{-| Maybe な日時文字列からタイムゾーン変換した日時を取得
 
 Nothing の場合は "-" を返す。
 
 -}
-formatMaybeDateTime : Maybe String -> String
-formatMaybeDateTime maybeDateTime =
+formatMaybeDateTime : Time.Zone -> Maybe String -> String
+formatMaybeDateTime zone maybeDateTime =
     case maybeDateTime of
         Just dateTime ->
-            formatDateTime dateTime
+            formatDateTime zone dateTime
 
         Nothing ->
             "-"
+
+
+
+-- 内部関数
+
+
+{-| Time.Posix を日付文字列にフォーマット（YYYY-MM-DD）
+-}
+formatPosixDate : Time.Zone -> Time.Posix -> String
+formatPosixDate zone posix =
+    let
+        year =
+            Time.toYear zone posix
+
+        month =
+            Time.toMonth zone posix |> monthToNumber
+
+        day =
+            Time.toDay zone posix
+    in
+    String.fromInt year
+        ++ "-"
+        ++ padZero month
+        ++ "-"
+        ++ padZero day
+
+
+{-| Time.Posix を時刻文字列にフォーマット（HH:MM）
+-}
+formatPosixTime : Time.Zone -> Time.Posix -> String
+formatPosixTime zone posix =
+    let
+        hour =
+            Time.toHour zone posix
+
+        minute =
+            Time.toMinute zone posix
+    in
+    padZero hour ++ ":" ++ padZero minute
+
+
+{-| Time.Month を数値に変換
+-}
+monthToNumber : Time.Month -> Int
+monthToNumber month =
+    case month of
+        Time.Jan ->
+            1
+
+        Time.Feb ->
+            2
+
+        Time.Mar ->
+            3
+
+        Time.Apr ->
+            4
+
+        Time.May ->
+            5
+
+        Time.Jun ->
+            6
+
+        Time.Jul ->
+            7
+
+        Time.Aug ->
+            8
+
+        Time.Sep ->
+            9
+
+        Time.Oct ->
+            10
+
+        Time.Nov ->
+            11
+
+        Time.Dec ->
+            12
+
+
+{-| 数値を2桁のゼロパディング文字列に変換
+-}
+padZero : Int -> String
+padZero n =
+    if n < 10 then
+        "0" ++ String.fromInt n
+
+    else
+        String.fromInt n

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -115,6 +115,9 @@ const app = Elm.Main.init({
   flags: {
     apiBaseUrl: import.meta.env.VITE_API_BASE_URL || "",
     timestamp: Date.now(),
+    // JavaScript の getTimezoneOffset() は UTC - ローカル（分）を返す（JST なら -540）
+    // Elm の Time.customZone はローカル - UTC（分）を期待するので符号を反転する
+    timezoneOffsetMinutes: -new Date().getTimezoneOffset(),
   },
 });
 


### PR DESCRIPTION
## Summary

時刻表示がUTCのままになっている問題を修正。
`elm/time` + `rtfeldman/elm-iso8601-date-strings` を使い、ブラウザのローカルタイムゾーンに変換して表示する。

## Related

Closes #200

## Test plan

- [x] UTC の ISO 8601 文字列がローカルタイムゾーンの日付に変換される
- [x] UTC の ISO 8601 文字列がローカルタイムゾーンの日時に変換される
- [x] Nothing の場合は "-" を返す
- [x] 日付境界をまたぐケース（UTC 23:30 → JST 翌日 08:30）が正しく変換される
- [x] パース失敗時は元の文字列がフォールバックされる
- [x] `just check-all` が通る（lint + 全テスト + ビルド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)