### PR TITLE
#211 Add accessibility and UX polish

### DIFF
--- a/frontend/src/Component/Button.elm
+++ b/frontend/src/Component/Button.elm
@@ -1,4 +1,4 @@
-module Component.Button exposing (Variant(..), link, variantClass, view)
+module Component.Button exposing (Variant(..), link, variantClass, view, viewWithAttrs)
 
 {-| ボタンコンポーネント
 
@@ -83,13 +83,33 @@ view :
     }
     -> List (Html msg)
     -> Html msg
-view config children =
+view config =
+    viewWithAttrs config []
+
+
+{-| 追加属性付きアクションボタン
+
+`view` と同じだが、`id` 等の追加属性を指定できる。
+`Browser.Dom.focus` のターゲットにする場合などに使用する。
+
+-}
+viewWithAttrs :
+    { variant : Variant
+    , disabled : Bool
+    , onClick : msg
+    }
+    -> List (Html.Attribute msg)
+    -> List (Html msg)
+    -> Html msg
+viewWithAttrs config extraAttrs children =
     button
-        [ type_ "button"
-        , class (baseClass ++ " " ++ variantClass config.variant ++ " disabled:opacity-50 disabled:cursor-not-allowed")
-        , disabled config.disabled
-        , onClick config.onClick
-        ]
+        ([ type_ "button"
+         , class (baseClass ++ " " ++ variantClass config.variant ++ " disabled:opacity-50 disabled:cursor-not-allowed")
+         , disabled config.disabled
+         , onClick config.onClick
+         ]
+            ++ extraAttrs
+        )
         children
 
 

--- a/frontend/src/Component/ConfirmDialog.elm
+++ b/frontend/src/Component/ConfirmDialog.elm
@@ -1,4 +1,4 @@
-module Component.ConfirmDialog exposing (ActionStyle(..), view)
+module Component.ConfirmDialog exposing (ActionStyle(..), cancelButtonId, view)
 
 {-| 確認ダイアログコンポーネント
 
@@ -76,11 +76,12 @@ view config =
                 [ h2 [ class "text-lg font-semibold text-secondary-900" ] [ text config.title ]
                 , p [ class "mt-2 text-sm text-secondary-600" ] [ text config.message ]
                 , div [ class "mt-6 flex justify-end gap-3" ]
-                    [ Button.view
+                    [ Button.viewWithAttrs
                         { variant = Button.Outline
                         , disabled = False
                         , onClick = config.onCancel
                         }
+                        [ id cancelButtonId ]
                         [ text config.cancelLabel ]
                     , Button.view
                         { variant = actionStyleToVariant config.actionStyle
@@ -92,6 +93,16 @@ view config =
                 ]
             ]
         ]
+
+
+{-| キャンセルボタンの HTML id
+
+ダイアログ表示時の `Browser.Dom.focus` ターゲットとして使用する。
+
+-}
+cancelButtonId : String
+cancelButtonId =
+    "confirm-dialog-cancel"
 
 
 {-| ActionStyle を Button.Variant にマッピング

--- a/frontend/src/Component/LoadingSpinner.elm
+++ b/frontend/src/Component/LoadingSpinner.elm
@@ -26,10 +26,17 @@ import Html.Attributes exposing (..)
 
 
 {-| ローディングスピナーを表示
+
+`role="status"` により、スクリーンリーダーがコンテンツの変化をアナウンスする。
+
 -}
 view : Html msg
 view =
-    div [ class "flex flex-col items-center justify-center py-8" ]
+    div
+        [ class "flex flex-col items-center justify-center py-8"
+        , attribute "role" "status"
+        , attribute "aria-label" "読み込み中"
+        ]
         [ div [ class "h-8 w-8 animate-spin rounded-full border-4 border-secondary-100 border-t-primary-600" ] []
         , p [ class "mt-4 text-secondary-500" ] [ text "読み込み中..." ]
         ]

--- a/frontend/src/Component/MessageAlert.elm
+++ b/frontend/src/Component/MessageAlert.elm
@@ -51,9 +51,9 @@ viewSuccessMessage : msg -> Maybe String -> Html msg
 viewSuccessMessage onDismiss maybeMessage =
     case maybeMessage of
         Just message ->
-            div [ class "flex items-center justify-between rounded-lg bg-success-50 p-4 text-success-700" ]
+            div [ class "flex items-center justify-between rounded-lg bg-success-50 p-4 text-success-700", attribute "role" "alert" ]
                 [ text message
-                , button [ class "ml-4 cursor-pointer bg-transparent border-0 text-lg", onClick onDismiss ] [ text "×" ]
+                , button [ class "ml-4 cursor-pointer bg-transparent border-0 text-lg", attribute "aria-label" "閉じる", onClick onDismiss ] [ text "×" ]
                 ]
 
         Nothing ->
@@ -64,9 +64,9 @@ viewErrorMessage : msg -> Maybe String -> Html msg
 viewErrorMessage onDismiss maybeMessage =
     case maybeMessage of
         Just message ->
-            div [ class "flex items-center justify-between rounded-lg bg-error-50 p-4 text-error-700" ]
+            div [ class "flex items-center justify-between rounded-lg bg-error-50 p-4 text-error-700", attribute "role" "alert" ]
                 [ text message
-                , button [ class "ml-4 cursor-pointer bg-transparent border-0 text-lg", onClick onDismiss ] [ text "×" ]
+                , button [ class "ml-4 cursor-pointer bg-transparent border-0 text-lg", attribute "aria-label" "閉じる", onClick onDismiss ] [ text "×" ]
                 ]
 
         Nothing ->

--- a/frontend/src/Main.elm
+++ b/frontend/src/Main.elm
@@ -469,13 +469,15 @@ view : Model -> Browser.Document Msg
 view model =
     { title = pageTitle model.route ++ " | RingiFlow"
     , body =
-        [ div [ class "flex h-screen bg-secondary-50 overflow-hidden" ]
+        [ a [ class "sr-only focus:not-sr-only focus:absolute focus:z-50 focus:bg-white focus:p-4 focus:text-primary-600", href "#main-content" ]
+            [ text "メインコンテンツにスキップ" ]
+        , div [ class "flex h-screen bg-secondary-50 overflow-hidden" ]
             [ viewSidebar model.route model.sidebarOpen model.shared
             , viewMobileOverlay model.sidebarOpen
             , div [ class "flex flex-col flex-1 overflow-hidden" ]
                 [ viewTopBar
                 , main_
-                    [ class "flex-1 overflow-y-auto p-6" ]
+                    [ id "main-content", class "flex-1 overflow-y-auto p-6" ]
                     [ div [ class "mx-auto max-w-5xl" ]
                         [ viewPage model ]
                     ]
@@ -611,6 +613,7 @@ viewTopBar =
         [ -- ハンバーガーボタン（モバイルのみ）
           button
             [ class "mr-4 rounded-lg p-2 text-secondary-500 hover:bg-secondary-50 lg:hidden"
+            , attribute "aria-label" "メニューを開く"
             , onClick ToggleSidebar
             ]
             [ iconMenu ]

--- a/frontend/src/Page/Workflow/Detail.elm
+++ b/frontend/src/Page/Workflow/Detail.elm
@@ -31,6 +31,7 @@ import Api exposing (ApiError)
 import Api.ErrorMessage as ErrorMessage
 import Api.Workflow as WorkflowApi
 import Api.WorkflowDefinition as WorkflowDefinitionApi
+import Browser.Dom
 import Browser.Events
 import Component.Badge as Badge
 import Component.Button as Button
@@ -48,6 +49,7 @@ import Json.Decode as Decode
 import RemoteData exposing (RemoteData(..))
 import Route
 import Shared exposing (Shared)
+import Task
 import Time
 import Util.DateFormat as DateFormat
 import Util.KeyEvent as KeyEvent
@@ -139,6 +141,7 @@ type Msg
     | GotApproveResult (Result ApiError WorkflowInstance)
     | GotRejectResult (Result ApiError WorkflowInstance)
     | DismissMessage
+    | NoOp
 
 
 {-| 状態更新
@@ -193,12 +196,12 @@ update msg model =
 
         ClickApprove step ->
             ( { model | pendingAction = Just (ConfirmApprove step) }
-            , Cmd.none
+            , focusDialogCancel
             )
 
         ClickReject step ->
             ( { model | pendingAction = Just (ConfirmReject step) }
-            , Cmd.none
+            , focusDialogCancel
             )
 
         ConfirmAction ->
@@ -243,6 +246,17 @@ update msg model =
             ( { model | errorMessage = Nothing, successMessage = Nothing }
             , Cmd.none
             )
+
+        NoOp ->
+            ( model, Cmd.none )
+
+
+{-| ダイアログ表示時にキャンセルボタンへフォーカスを移動
+-}
+focusDialogCancel : Cmd Msg
+focusDialogCancel =
+    Browser.Dom.focus ConfirmDialog.cancelButtonId
+        |> Task.attempt (\_ -> NoOp)
 
 
 {-| 空文字列を Nothing に変換
@@ -539,7 +553,7 @@ viewCommentInput comment =
         [ label [ for "approval-comment", class "block text-sm font-medium text-secondary-700" ] [ text "コメント（任意）" ]
         , textarea
             [ id "approval-comment"
-            , class "w-full rounded-lg border border-secondary-300 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            , class "w-full rounded-lg border border-secondary-300 bg-white px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-primary-500"
             , value comment
             , onInput UpdateComment
             , placeholder "承認/却下の理由を入力..."

--- a/frontend/src/Page/Workflow/List.elm
+++ b/frontend/src/Page/Workflow/List.elm
@@ -232,8 +232,8 @@ viewStatusFilter currentFilter =
             currentFilter == maybeStatus
     in
     div [ class "mb-4 flex items-center gap-2" ]
-        [ label [] [ text "ステータス: " ]
-        , select [ onInput (statusFromFilterValue >> SetStatusFilter), class "rounded border border-secondary-100 bg-white px-3 py-1.5 text-sm" ]
+        [ label [ for "status-filter" ] [ text "ステータス: " ]
+        , select [ id "status-filter", onInput (statusFromFilterValue >> SetStatusFilter), class "rounded border border-secondary-100 bg-white px-3 py-1.5 text-sm" ]
             (List.map
                 (\( maybeStatus, label_ ) ->
                     option

--- a/frontend/src/Page/Workflow/New.elm
+++ b/frontend/src/Page/Workflow/New.elm
@@ -642,7 +642,7 @@ viewFormInputs model definition =
                 , Html.Attributes.value model.title
                 , Html.Events.onInput UpdateTitle
                 , placeholder "申請のタイトルを入力"
-                , class "w-full rounded border border-secondary-300 bg-white px-3 py-3 text-base outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                , class "w-full rounded border border-secondary-300 bg-white px-3 py-3 text-base outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-primary-500"
                 ]
                 []
             , viewTitleError model
@@ -679,7 +679,7 @@ viewApproverSection model =
                 , Html.Attributes.value model.approverInput
                 , Html.Events.onInput UpdateApproverInput
                 , placeholder "承認者のユーザー ID を入力"
-                , class "w-full rounded border border-secondary-300 bg-white px-3 py-3 text-base outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                , class "w-full rounded border border-secondary-300 bg-white px-3 py-3 text-base outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:border-primary-500"
                 ]
                 []
             , viewApproverError model


### PR DESCRIPTION
## Issue

Closes #211

## Summary

Epic #173 の Story: アクセシビリティと UX ポリッシュを追加する。

### Phase 3: セマンティック・ARIA 改善
- `LoadingSpinner`: `role="status"` + `aria-label="読み込み中"` 追加
- `MessageAlert`: 成功/エラーに `role="alert"` 追加、×ボタンに `aria-label="閉じる"` 追加
- `Main.elm`: スキップリンク追加、`main` に `id "main-content"` 付与、ハンバーガーに `aria-label` 追加
- `Workflow/List.elm`: `<label for>` と `<select id>` の紐付け

### Phase 4: フォーカス管理
- `Button.elm`: `viewWithAttrs` 関数追加（追加属性対応）
- `ConfirmDialog.elm`: `cancelButtonId` 公開（フォーカスターゲット用）
- `Workflow/Detail.elm`, `Task/Detail.elm`: ダイアログ表示時に `Browser.Dom.focus` でキャンセルボタンへフォーカス移動
- 全フォーム入力: `focus:` → `focus-visible:`（キーボードフォーカスのみリング表示）

### Phase 5: フォーム a11y 改善
- `DynamicForm.elm`: `ariaErrorAttrs` ヘルパー追加、バリデーションエラー時に `aria-invalid="true"` + `aria-describedby` で入力とエラーメッセージを関連付け

## Test plan

- [x] `just check-all` 通過（リント + 139 テスト + ビルド）
- [ ] Tab キーでフォーカスリングが表示されること（`focus-visible:`）
- [ ] マウスクリック時にフォーカスリングが表示されないこと
- [ ] 承認/却下ボタンクリック → 確認ダイアログのキャンセルボタンにフォーカスが移動すること
- [ ] ESC キーで確認ダイアログが閉じること
- [ ] スキップリンク: Tab で表示 → Enter で `#main-content` にジャンプ
- [ ] スクリーンリーダー: ローディングスピナーが「読み込み中」と読み上げること

## 変更ファイル（10ファイル）

| ファイル | 変更内容 |
|---------|---------|
| `Component/Button.elm` | `viewWithAttrs` 追加 |
| `Component/ConfirmDialog.elm` | `cancelButtonId` 公開 |
| `Component/LoadingSpinner.elm` | `role="status"`, `aria-label` |
| `Component/MessageAlert.elm` | `role="alert"`, `aria-label` |
| `Form/DynamicForm.elm` | `ariaErrorAttrs`, `aria-invalid`, `aria-describedby`, `focus-visible:` |
| `Main.elm` | スキップリンク, `id "main-content"`, `aria-label` |
| `Page/Task/Detail.elm` | `focusDialogCancel`, `focus-visible:` |
| `Page/Workflow/Detail.elm` | `focusDialogCancel`, `focus-visible:` |
| `Page/Workflow/List.elm` | `for`/`id` 紐付け |
| `Page/Workflow/New.elm` | `focus-visible:` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)