### PR TITLE
Strengthen Hurl API test assertions and add assertion policy

### DIFF
--- a/.claude/rules/api-test.md
+++ b/.claude/rules/api-test.md
@@ -1,0 +1,103 @@
+---
+paths:
+  - "tests/api/**/*.hurl"
+---
+
+# API テスト（Hurl）のルール
+
+このルールは Hurl API テストファイルを追加・変更する際に適用される。
+
+## アサーション方針: 値の決定性で手段を選ぶ
+
+テストの価値を最大化するため、各フィールドの**値の決定性**に基づいてアサーション手段を選択する。
+
+### 判断基準
+
+| 優先度 | 値の性質 | アサーション | 例 |
+|--------|---------|-------------|-----|
+| 1 | 決定的（seed データ・リクエスト入力・ドメインロジックから確定） | `==` 厳密一致 | `status == "Draft"`, `version == 1` |
+| 2 | 非決定的だが形式が既知（タイムスタンプ、自動生成 UUID、トークン） | `matches` パターン検証 | `created_at matches "^\\d{4}-\\d{2}-\\d{2}T"` |
+| 3 | 配列型 | `count` 型＋件数検証 | `roles count >= 0` |
+| 4 | 上記のいずれにも該当しない | `exists`（最終手段） | — |
+
+`exists` は「フィールドが存在する」しか保証しない（null でも通る）。**`exists` で済ませてよいのは、値の性質が上記 1〜3 に該当しない場合のみ。**
+
+### 決定的な値の見極め方
+
+API テストは seed データを投入したうえで実行する。以下の値は決定的であり、`==` で検証できる:
+
+| 値の出所 | 例 |
+|---------|-----|
+| seed データ（マイグレーション） | `tenant_name == "Development Tenant"` |
+| リクエストボディの入力値 | `title == "経費申請"` |
+| テンプレート変数（`vars.env`） | `initiated_by.id == "{{admin_id}}"` |
+| ドメインロジックの不変条件 | `version == 1`（新規作成時）、`status == "Draft"` |
+| ハードコードされた定数 | `current_step_id == "approval"` |
+| 前のリクエストで Capture した値 | `display_id == "{{workflow_display_id}}"` |
+
+判定テスト: 「テストを何度実行しても同じ値になるか？」→ Yes なら `==` を使う。
+
+### Capture → == パターン
+
+複数リクエストにまたがるテストでは、前のレスポンスの値を Capture し、後のレスポンスで `==` で比較する。これにより**値の安定性**（リクエスト間で値が変わらないこと）を検証できる。
+
+```hurl
+# 作成時に Capture
+HTTP 201
+[Captures]
+workflow_id: jsonpath "$.data.id"
+workflow_display_id: jsonpath "$.data.display_id"
+
+# 更新後に == で検証（同じ値であることを確認）
+HTTP 200
+[Asserts]
+jsonpath "$.data.id" == "{{workflow_id}}"
+jsonpath "$.data.display_id" == "{{workflow_display_id}}"
+```
+
+## 必須チェック項目
+
+### 1. OpenAPI required フィールドの検証
+
+OpenAPI 仕様で `required` に含まれるフィールドは、**すべて**テストでアサーションする。
+
+確認手順: OpenAPI の該当スキーマの `required` 配列と、テストのアサーションを突合する。
+
+### 2. Cookie セキュリティ属性の検証
+
+認証関連の Cookie を設定・クリアするエンドポイントでは、以下のセキュリティ属性を検証する:
+
+```hurl
+header "Set-Cookie" contains "HttpOnly"
+header "Set-Cookie" contains "SameSite=Lax"
+header "Set-Cookie" contains "Path=/"
+```
+
+注: `Secure` 属性はテスト環境（HTTP）では付与されないため、検証対象外。
+
+### 3. 状態遷移の検証
+
+状態変更 API（submit、approve、reject 等）では、変更前後の状態を検証する:
+
+- `status` の期待値を `==` で検証
+- `version` のインクリメントを `==` で検証（更新回数が確定している場合）
+- null → 非 null に変わるフィールドの値を検証
+
+## AI エージェントへの指示
+
+API テストのアサーションを追加・変更する際:
+
+1. 各フィールドの値が決定的かどうかを実装コードで確認する
+2. 判断基準に従い、最も厳密なアサーションを選択する
+3. OpenAPI の required フィールドがすべてアサーションされているか突合する
+
+**禁止事項:**
+
+- 値が決定的であるにもかかわらず `exists` や `isString` で済ませること
+- OpenAPI の required フィールドをアサーションせずにコミットすること
+
+## 参照
+
+- Hurl ナレッジベース: [docs/06_ナレッジベース/devtools/hurl.md](../../docs/06_ナレッジベース/devtools/hurl.md)
+- API 実装ルール: [.claude/rules/api.md](api.md)
+- OpenAPI 仕様: [openapi/openapi.yaml](../../openapi/openapi.yaml)

--- a/docs/06_ナレッジベース/devtools/hurl.md
+++ b/docs/06_ナレッジベース/devtools/hurl.md
@@ -170,6 +170,37 @@ cookie "session_id" exists
 cookie "session_id[HttpOnly]" exists
 ```
 
+## アサーション一覧と使い分け
+
+→ ルール: [`.claude/rules/api-test.md`](../../../.claude/rules/api-test.md)
+
+### アサーション種別
+
+| アサーション | 対象型 | 用途 | 例 |
+|-------------|--------|------|-----|
+| `==` | 全型 | 厳密一致。決定的な値に使う | `jsonpath "$.status" == "Draft"` |
+| `matches` | 文字列 | 正規表現パターン検証。非決定的な値の形式確認に使う | `jsonpath "$.created_at" matches "^\\d{4}-\\d{2}-\\d{2}T"` |
+| `contains` | 文字列 | 部分文字列の包含確認。ヘッダー値の検証に使う | `header "Set-Cookie" contains "HttpOnly"` |
+| `startsWith` | 文字列 | プレフィックス一致 | `jsonpath "$.id" startsWith "WF-"` |
+| `count` | 配列 | 要素数の検証。配列型の確認に使う | `jsonpath "$.roles" count >= 0` |
+| `exists` | 全型 | フィールドの存在確認（null でも通る）。最終手段 | `jsonpath "$.data.id" exists` |
+| `not exists` | 全型 | フィールドの非存在確認 | `jsonpath "$.errors" not exists` |
+| `isString` | 全型 | 型チェック（`isInteger`, `isBoolean`, `isCollection` 等もあり） | `jsonpath "$.name" isString` |
+
+注意:
+- `matches` は**文字列型専用**。配列やオブジェクトには使えない
+- `count` は配列型専用。文字列やオブジェクトには使えない
+- `exists` は null 値でも通るため、「値がある」ことの証明にはならない
+
+### よく使う正規表現パターン
+
+| パターン | 用途 | 正規表現 |
+|---------|------|---------|
+| 表示用 ID | `WF-42` 形式 | `"^WF-\\d+$"` |
+| RFC 3339 タイムスタンプ（先頭） | `2026-01-15T...` 形式 | `"^\\d{4}-\\d{2}-\\d{2}T"` |
+| CSRF トークン | 64文字の16進数 | `"^[a-f0-9]{64}$"` |
+| UUID | `550e8400-...` 形式 | `"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"` |
+
 ## 注意点: Cookie の自動管理
 
 hurl は**同一ファイル内で Cookie を自動管理**する。

--- a/tests/api/hurl/auth/login.hurl
+++ b/tests/api/hurl/auth/login.hurl
@@ -26,9 +26,11 @@ jsonpath "$.data.user.email" == "admin@example.com"
 jsonpath "$.data.user.name" == "管理者"
 jsonpath "$.data.user.tenant_id" == "00000000-0000-0000-0000-000000000001"
 jsonpath "$.data.user.roles" exists
-# セッション Cookie が HttpOnly で設定される（XSS 対策）
+# セッション Cookie がセキュリティ属性付きで設定される
 header "Set-Cookie" contains "session_id="
 header "Set-Cookie" contains "HttpOnly"
+header "Set-Cookie" contains "SameSite=Lax"
+header "Set-Cookie" contains "Path=/"
 
 
 # =============================================================================

--- a/tests/api/hurl/auth/logout.hurl
+++ b/tests/api/hurl/auth/logout.hurl
@@ -47,9 +47,12 @@ Cookie: session_id={{session_cookie}}
 
 HTTP 204
 [Asserts]
-# Cookie がクリアされる（Max-Age=0 で無効化）
+# Cookie がクリアされる（Max-Age=0 で無効化、セキュリティ属性維持）
 header "Set-Cookie" contains "session_id="
 header "Set-Cookie" contains "Max-Age=0"
+header "Set-Cookie" contains "HttpOnly"
+header "Set-Cookie" contains "SameSite=Lax"
+header "Set-Cookie" contains "Path=/"
 
 
 # =============================================================================

--- a/tests/api/hurl/auth/me.hurl
+++ b/tests/api/hurl/auth/me.hurl
@@ -37,7 +37,7 @@ jsonpath "$.data.id" exists
 jsonpath "$.data.email" == "user@example.com"
 jsonpath "$.data.name" == "一般ユーザー"
 jsonpath "$.data.tenant_id" == "00000000-0000-0000-0000-000000000001"
-jsonpath "$.data.tenant_name" exists
-# フロントエンドでの権限チェックに使用
-jsonpath "$.data.roles" exists
-jsonpath "$.data.permissions" exists
+jsonpath "$.data.tenant_name" == "Development Tenant"
+# フロントエンドでの権限チェックに使用（配列型であることを検証）
+jsonpath "$.data.roles" count >= 0
+jsonpath "$.data.permissions" count >= 0

--- a/tests/api/hurl/workflow/create_workflow.hurl
+++ b/tests/api/hurl/workflow/create_workflow.hurl
@@ -53,18 +53,19 @@ HTTP 201
 [Asserts]
 # ワークフローインスタンスの情報が正しく返される
 jsonpath "$.data.id" exists
-jsonpath "$.data.display_id" exists
+jsonpath "$.data.display_id" matches "^WF-\\d+$"
 jsonpath "$.data.title" == "経費申請"
 jsonpath "$.data.definition_id" == "{{workflow_definition_id}}"
 jsonpath "$.data.status" == "Draft"
+jsonpath "$.data.version" == 1
 jsonpath "$.data.form_data.title" == "交通費"
 jsonpath "$.data.form_data.description" == "出張時の交通費"
 jsonpath "$.data.initiated_by.id" == "{{admin_id}}"
 jsonpath "$.data.initiated_by.name" == "{{admin_name}}"
 jsonpath "$.data.current_step_id" == null
 jsonpath "$.data.submitted_at" == null
-jsonpath "$.data.created_at" exists
-jsonpath "$.data.updated_at" exists
+jsonpath "$.data.created_at" matches "^\\d{4}-\\d{2}-\\d{2}T"
+jsonpath "$.data.updated_at" matches "^\\d{4}-\\d{2}-\\d{2}T"
 
 [Captures]
 workflow_id: jsonpath "$.data.id"

--- a/tests/api/hurl/workflow/submit_workflow.hurl
+++ b/tests/api/hurl/workflow/submit_workflow.hurl
@@ -46,6 +46,7 @@ Content-Type: application/json
 HTTP 201
 [Captures]
 workflow_id: jsonpath "$.data.id"
+workflow_display_id: jsonpath "$.data.display_id"
 
 # =============================================================================
 # 正常系: ワークフローを申請できる
@@ -67,11 +68,12 @@ HTTP 200
 [Asserts]
 # ワークフローのステータスが更新される
 jsonpath "$.data.id" == "{{workflow_id}}"
-jsonpath "$.data.display_id" exists
+jsonpath "$.data.display_id" == "{{workflow_display_id}}"
 jsonpath "$.data.title" == "経費申請"
 jsonpath "$.data.status" == "InProgress"
-jsonpath "$.data.current_step_id" exists
-jsonpath "$.data.submitted_at" exists
+jsonpath "$.data.version" == 2
+jsonpath "$.data.current_step_id" == "approval"
+jsonpath "$.data.submitted_at" matches "^\\d{4}-\\d{2}-\\d{2}T"
 jsonpath "$.data.initiated_by.id" == "{{admin_id}}"
 jsonpath "$.data.initiated_by.name" == "{{admin_name}}"
 


### PR DESCRIPTION
## Issue

Related to #207

## Summary

Hurl API テストのアサーションを全面的に改善し、テスト価値を最大化した。併せて、アサーション方針をルール・ナレッジベースとして文書化した。

## Changes

### アサーション改善（5ファイル）

- `create_workflow.hurl`: `display_id` 形式検証、`version == 1` 追加、タイムスタンプ形式検証
- `submit_workflow.hurl`: `display_id` Capture→== 安定性検証、`version == 2`、`current_step_id == "approval"`
- `login.hurl`: Cookie に `SameSite=Lax`、`Path=/` 検証追加
- `logout.hurl`: Cookie に `HttpOnly`、`SameSite=Lax`、`Path=/` 検証追加
- `me.hurl`: `tenant_name` 厳密一致、`roles`/`permissions` 配列型検証

### 方針文書化（2ファイル）

- `.claude/rules/api-test.md`: アサーション選択の判断基準（値の決定性に基づく）
- `docs/06_ナレッジベース/devtools/hurl.md`: アサーション種別一覧と正規表現パターン集を追記

### 原則

値の決定性でアサーション手段を選ぶ:
1. 決定的な値（seed / request / domain logic） → `==` 厳密一致
2. 非決定的だが形式が既知 → `matches` パターン検証
3. 配列型 → `count` 型＋件数検証
4. 上記いずれにも該当しない → `exists`（最終手段）

## Test plan

- [x] `just test-api` が全 8 ファイル 100% パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)