### PR TITLE
#224 Add /review-and-merge skill for Claude Code

### DIFF
--- a/.claude/skills/review-and-merge/SKILL.md
+++ b/.claude/skills/review-and-merge/SKILL.md
@@ -43,7 +43,7 @@ gh pr checks
 
 | 状態 | 対応 |
 |------|------|
-| pending / in_progress | 「レビュー実行中です。完了まで待ちますか？」と確認。待つ場合は定期的にポーリング |
+| pending / in_progress | 「レビュー実行中です。完了まで待ちますか？」と確認。待つ場合は 20〜30 秒間隔でポーリング |
 | success / failure | Step 3 へ |
 | 見つからない | 「Claude Auto Review は CI 完了後にトリガーされます。CI の状態を確認してください」と案内 |
 


### PR DESCRIPTION
## Issue

Closes #224

## Summary

Claude Code のスキルとして `/review-and-merge` を追加。

PR を Ready for Review にした後の「Claude Code Action レビュー確認 → 対応 → マージ」フローを半自動化するスキル。

### スキルのフロー

1. PR 状態確認（Draft / CI / Ready）
2. Claude Auto Review 完了確認
3. レビューコメント取得・重大度別に分類して提示
4. 各コメントに対して修正案を提示 → ユーザー承認で適用
5. マージ（`--squash --delete-branch`）+ ローカルブランチ削除

## Test plan

スキルファイルの追加のみ（コード変更なし）のため、実際の PR で `/review-and-merge` を実行して動作確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)