### PR TITLE
Optimize Claude Code permission settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,6 +79,8 @@
       "Bash(git clean -f:*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
+      "Bash(git checkout .:*)",
+      "Bash(git restore .:*)",
       "Bash(git branch -D:*)",
       "Bash(rm -rf:*)",
       "Bash(sudo:*)",


### PR DESCRIPTION
## Issue

なし

## 概要

Claude Code の permission 設定を最適化し、開発中の許可プロンプトによるタイムロスを削減する。

## 変更内容

### 1. ask → allow への移動

頻繁に使うコマンドの許可確認を不要にした:

- `git add / commit / push / checkout / switch`
- `npm install / ci`

**安全性の担保:**
- CLAUDE.md のルール（明示的指示時のみコミット・プッシュ）
- pre-commit hook による検証
- deny ルールによる危険コマンドのブロック

### 2. allow セクションのワイルドカード統合

標準ツールの個別エントリをワイルドカードパターンに統合（77行 → 44行）:

| 統合対象 | 変更前 | 変更後 |
|---------|--------|--------|
| git | 10エントリ | `Bash(git *)` |
| cargo | 8エントリ | `Bash(cargo *)` |
| npm | 6エントリ | `Bash(npm *)` |
| gh | 9エントリ | `Bash(gh *)` |
| terraform | 4エントリ | `Bash(terraform *)` |

**据え置き:** `just` コマンドはプロジェクト固有のため、一覧性を維持して個別エントリのまま。

## Test plan

- [ ] Claude Code セッションで `just check-all` が許可プロンプトなしで実行される
- [ ] `git commit` が許可プロンプトなしで実行される
- [ ] `.env` の読み取りが deny される（既存の安全ネット維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)