### PR TITLE
#222 Introduce parameter structs for new/from_db

### DIFF
--- a/backend/apps/core-service/src/usecase/dashboard.rs
+++ b/backend/apps/core-service/src/usecase/dashboard.rs
@@ -111,6 +111,8 @@ mod tests {
       user::UserId,
       value_objects::{DisplayNumber, Version},
       workflow::{
+         NewWorkflowInstance,
+         NewWorkflowStep,
          WorkflowDefinitionId,
          WorkflowInstance,
          WorkflowInstanceId,
@@ -299,45 +301,45 @@ mod tests {
       let step_repo = MockWorkflowStepRepository::new();
 
       let now = Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "テスト申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "テスト申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
       // Active ステップ（カウント対象）
-      let active_step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
-         Utc::now(),
-      )
+      let active_step = WorkflowStep::new(NewWorkflowStep {
+         id:          WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id:     "approval".to_string(),
+         step_name:   "承認".to_string(),
+         step_type:   "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
+         now:         Utc::now(),
+      })
       .activated(Utc::now());
       step_repo.insert(&active_step).await.unwrap();
 
       // Pending ステップ（カウント対象外）
-      let pending_step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "review".to_string(),
-         "レビュー".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
-         Utc::now(),
-      );
+      let pending_step = WorkflowStep::new(NewWorkflowStep {
+         id:          WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id:     "review".to_string(),
+         step_name:   "レビュー".to_string(),
+         step_type:   "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
+         now:         Utc::now(),
+      });
       step_repo.insert(&pending_step).await.unwrap();
 
       let usecase = DashboardUseCaseImpl::new(instance_repo, step_repo);
@@ -360,48 +362,48 @@ mod tests {
       let now = Utc::now();
 
       // InProgress インスタンス（カウント対象）
-      let in_progress = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "申請中1".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let in_progress = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "申請中1".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&in_progress).await.unwrap();
 
       // Draft インスタンス（カウント対象外）
-      let draft = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(101).unwrap(),
-         "下書き".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let draft = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(101).unwrap(),
+         title: "下書き".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      );
+      });
       instance_repo.insert(&draft).await.unwrap();
 
       // Approved インスタンス（カウント対象外）
-      let approved = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(102).unwrap(),
-         "承認済み".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let approved = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(102).unwrap(),
+         title: "承認済み".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .approved(now);
@@ -426,32 +428,32 @@ mod tests {
       let step_repo = MockWorkflowStepRepository::new();
 
       let now = Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "テスト申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "テスト申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
       // 完了済みステップ（今日 → カウント対象）
-      let completed_step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
-         Utc::now(),
-      )
+      let completed_step = WorkflowStep::new(NewWorkflowStep {
+         id:          WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id:     "approval".to_string(),
+         step_name:   "承認".to_string(),
+         step_type:   "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
+         now:         Utc::now(),
+      })
       .activated(Utc::now())
       .approve(Some("OK".to_string()), Utc::now())
       .unwrap();
@@ -499,32 +501,32 @@ mod tests {
       let now = Utc::now();
 
       // user_id が申請した InProgress インスタンス
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "ユーザーAの申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "ユーザーAの申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
       // approver_id にアサインされた Active ステップ
-      let step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
-         Utc::now(),
-      )
+      let step = WorkflowStep::new(NewWorkflowStep {
+         id:          WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id:     "approval".to_string(),
+         step_name:   "承認".to_string(),
+         step_type:   "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
+         now:         Utc::now(),
+      })
       .activated(Utc::now());
       step_repo.insert(&step).await.unwrap();
 

--- a/backend/apps/core-service/src/usecase/task.rs
+++ b/backend/apps/core-service/src/usecase/task.rs
@@ -187,6 +187,8 @@ mod tests {
       user::UserId,
       value_objects::{DisplayNumber, Version},
       workflow::{
+         NewWorkflowInstance,
+         NewWorkflowStep,
          WorkflowDefinitionId,
          WorkflowInstance,
          WorkflowInstanceId,
@@ -423,45 +425,45 @@ mod tests {
 
       // ワークフローインスタンスを作成
       let now = chrono::Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "テスト申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "テスト申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
       // Active ステップ
-      let active_step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
+      let active_step = WorkflowStep::new(NewWorkflowStep {
+         id: WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id: "approval".to_string(),
+         step_name: "承認".to_string(),
+         step_type: "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
          now,
-      )
+      })
       .activated(now);
       step_repo.insert(&active_step).await.unwrap();
 
       // Pending ステップ（同じ approver）
-      let pending_step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "review".to_string(),
-         "レビュー".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
+      let pending_step = WorkflowStep::new(NewWorkflowStep {
+         id: WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id: "review".to_string(),
+         step_name: "レビュー".to_string(),
+         step_type: "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
          now,
-      );
+      });
       step_repo.insert(&pending_step).await.unwrap();
 
       let usecase = TaskUseCaseImpl::new(instance_repo, step_repo, MockUserRepository);
@@ -487,31 +489,31 @@ mod tests {
       let step_repo = MockWorkflowStepRepository::new();
 
       let now = chrono::Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(101).unwrap(),
-         "経費精算申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(101).unwrap(),
+         title: "経費精算申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
-      let step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "部長承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
+      let step = WorkflowStep::new(NewWorkflowStep {
+         id: WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id: "approval".to_string(),
+         step_name: "部長承認".to_string(),
+         step_type: "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
          now,
-      )
+      })
       .activated(now);
       step_repo.insert(&step).await.unwrap();
 
@@ -539,31 +541,31 @@ mod tests {
       let step_repo = MockWorkflowStepRepository::new();
 
       let now = chrono::Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "テスト申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "テスト申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
-      let step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
+      let step = WorkflowStep::new(NewWorkflowStep {
+         id: WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id: "approval".to_string(),
+         step_name: "承認".to_string(),
+         step_type: "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
          now,
-      )
+      })
       .activated(now);
       step_repo.insert(&step).await.unwrap();
 
@@ -607,31 +609,31 @@ mod tests {
       let step_repo = MockWorkflowStepRepository::new();
 
       let now = chrono::Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "テスト申請".to_string(),
-         serde_json::json!({"note": "test"}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "テスト申請".to_string(),
+         form_data: serde_json::json!({"note": "test"}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
-      let step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
+      let step = WorkflowStep::new(NewWorkflowStep {
+         id: WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id: "approval".to_string(),
+         step_name: "承認".to_string(),
+         step_type: "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
          now,
-      )
+      })
       .activated(now);
       let step_id = step.id().clone();
       step_repo.insert(&step).await.unwrap();
@@ -681,31 +683,31 @@ mod tests {
       let step_repo = MockWorkflowStepRepository::new();
 
       let now = chrono::Utc::now();
-      let instance = WorkflowInstance::new(
-         WorkflowInstanceId::new(),
-         tenant_id.clone(),
-         WorkflowDefinitionId::new(),
-         Version::initial(),
-         DisplayNumber::new(100).unwrap(),
-         "テスト申請".to_string(),
-         serde_json::json!({}),
-         user_id.clone(),
+      let instance = WorkflowInstance::new(NewWorkflowInstance {
+         id: WorkflowInstanceId::new(),
+         tenant_id: tenant_id.clone(),
+         definition_id: WorkflowDefinitionId::new(),
+         definition_version: Version::initial(),
+         display_number: DisplayNumber::new(100).unwrap(),
+         title: "テスト申請".to_string(),
+         form_data: serde_json::json!({}),
+         initiated_by: user_id.clone(),
          now,
-      )
+      })
       .submitted(now)
       .unwrap()
       .with_current_step("approval".to_string(), now);
       instance_repo.insert(&instance).await.unwrap();
 
-      let step = WorkflowStep::new(
-         WorkflowStepId::new(),
-         instance.id().clone(),
-         "approval".to_string(),
-         "承認".to_string(),
-         "approval".to_string(),
-         Some(approver_id.clone()),
+      let step = WorkflowStep::new(NewWorkflowStep {
+         id: WorkflowStepId::new(),
+         instance_id: instance.id().clone(),
+         step_id: "approval".to_string(),
+         step_name: "承認".to_string(),
+         step_type: "approval".to_string(),
+         assigned_to: Some(approver_id.clone()),
          now,
-      )
+      })
       .activated(now);
       let step_id = step.id().clone();
       step_repo.insert(&step).await.unwrap();

--- a/backend/crates/infra/src/repository/workflow_instance_repository.rs
+++ b/backend/crates/infra/src/repository/workflow_instance_repository.rs
@@ -15,7 +15,13 @@ use ringiflow_domain::{
    tenant::TenantId,
    user::UserId,
    value_objects::{DisplayNumber, Version},
-   workflow::{WorkflowDefinitionId, WorkflowInstance, WorkflowInstanceId, WorkflowInstanceStatus},
+   workflow::{
+      WorkflowDefinitionId,
+      WorkflowInstance,
+      WorkflowInstanceId,
+      WorkflowInstanceRecord,
+      WorkflowInstanceStatus,
+   },
 };
 use sqlx::PgPool;
 
@@ -244,27 +250,29 @@ impl WorkflowInstanceRepository for PostgresWorkflowInstanceRepository {
          return Ok(None);
       };
 
-      let instance = WorkflowInstance::from_db(
-         WorkflowInstanceId::from_uuid(row.id),
-         TenantId::from_uuid(row.tenant_id),
-         WorkflowDefinitionId::from_uuid(row.definition_id),
-         Version::new(row.definition_version as u32)
+      let instance = WorkflowInstance::from_db(WorkflowInstanceRecord {
+         id: WorkflowInstanceId::from_uuid(row.id),
+         tenant_id: TenantId::from_uuid(row.tenant_id),
+         definition_id: WorkflowDefinitionId::from_uuid(row.definition_id),
+         definition_version: Version::new(row.definition_version as u32)
             .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-         DisplayNumber::try_from(row.display_number)
+         display_number: DisplayNumber::try_from(row.display_number)
             .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-         row.title,
-         row.form_data,
-         row.status
+         title: row.title,
+         form_data: row.form_data,
+         status: row
+            .status
             .parse::<WorkflowInstanceStatus>()
             .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-         Version::new(row.version as u32).map_err(|e| InfraError::Unexpected(e.to_string()))?,
-         row.current_step_id,
-         UserId::from_uuid(row.initiated_by),
-         row.submitted_at,
-         row.completed_at,
-         row.created_at,
-         row.updated_at,
-      );
+         version: Version::new(row.version as u32)
+            .map_err(|e| InfraError::Unexpected(e.to_string()))?,
+         current_step_id: row.current_step_id,
+         initiated_by: UserId::from_uuid(row.initiated_by),
+         submitted_at: row.submitted_at,
+         completed_at: row.completed_at,
+         created_at: row.created_at,
+         updated_at: row.updated_at,
+      });
 
       Ok(Some(instance))
    }
@@ -292,28 +300,29 @@ impl WorkflowInstanceRepository for PostgresWorkflowInstanceRepository {
       let instances = rows
          .into_iter()
          .map(|row| -> Result<WorkflowInstance, InfraError> {
-            Ok(WorkflowInstance::from_db(
-               WorkflowInstanceId::from_uuid(row.id),
-               TenantId::from_uuid(row.tenant_id),
-               WorkflowDefinitionId::from_uuid(row.definition_id),
-               Version::new(row.definition_version as u32)
+            Ok(WorkflowInstance::from_db(WorkflowInstanceRecord {
+               id: WorkflowInstanceId::from_uuid(row.id),
+               tenant_id: TenantId::from_uuid(row.tenant_id),
+               definition_id: WorkflowDefinitionId::from_uuid(row.definition_id),
+               definition_version: Version::new(row.definition_version as u32)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               DisplayNumber::try_from(row.display_number)
+               display_number: DisplayNumber::try_from(row.display_number)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               row.title,
-               row.form_data,
-               row.status
+               title: row.title,
+               form_data: row.form_data,
+               status: row
+                  .status
                   .parse::<WorkflowInstanceStatus>()
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               Version::new(row.version as u32)
+               version: Version::new(row.version as u32)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               row.current_step_id,
-               UserId::from_uuid(row.initiated_by),
-               row.submitted_at,
-               row.completed_at,
-               row.created_at,
-               row.updated_at,
-            ))
+               current_step_id: row.current_step_id,
+               initiated_by: UserId::from_uuid(row.initiated_by),
+               submitted_at: row.submitted_at,
+               completed_at: row.completed_at,
+               created_at: row.created_at,
+               updated_at: row.updated_at,
+            }))
          })
          .collect::<Result<Vec<_>, InfraError>>()?;
 
@@ -345,28 +354,29 @@ impl WorkflowInstanceRepository for PostgresWorkflowInstanceRepository {
       let instances = rows
          .into_iter()
          .map(|row| -> Result<WorkflowInstance, InfraError> {
-            Ok(WorkflowInstance::from_db(
-               WorkflowInstanceId::from_uuid(row.id),
-               TenantId::from_uuid(row.tenant_id),
-               WorkflowDefinitionId::from_uuid(row.definition_id),
-               Version::new(row.definition_version as u32)
+            Ok(WorkflowInstance::from_db(WorkflowInstanceRecord {
+               id: WorkflowInstanceId::from_uuid(row.id),
+               tenant_id: TenantId::from_uuid(row.tenant_id),
+               definition_id: WorkflowDefinitionId::from_uuid(row.definition_id),
+               definition_version: Version::new(row.definition_version as u32)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               DisplayNumber::try_from(row.display_number)
+               display_number: DisplayNumber::try_from(row.display_number)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               row.title,
-               row.form_data,
-               row.status
+               title: row.title,
+               form_data: row.form_data,
+               status: row
+                  .status
                   .parse::<WorkflowInstanceStatus>()
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               Version::new(row.version as u32)
+               version: Version::new(row.version as u32)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               row.current_step_id,
-               UserId::from_uuid(row.initiated_by),
-               row.submitted_at,
-               row.completed_at,
-               row.created_at,
-               row.updated_at,
-            ))
+               current_step_id: row.current_step_id,
+               initiated_by: UserId::from_uuid(row.initiated_by),
+               submitted_at: row.submitted_at,
+               completed_at: row.completed_at,
+               created_at: row.created_at,
+               updated_at: row.updated_at,
+            }))
          })
          .collect::<Result<Vec<_>, InfraError>>()?;
 
@@ -404,28 +414,29 @@ impl WorkflowInstanceRepository for PostgresWorkflowInstanceRepository {
       let instances = rows
          .into_iter()
          .map(|row| -> Result<WorkflowInstance, InfraError> {
-            Ok(WorkflowInstance::from_db(
-               WorkflowInstanceId::from_uuid(row.id),
-               TenantId::from_uuid(row.tenant_id),
-               WorkflowDefinitionId::from_uuid(row.definition_id),
-               Version::new(row.definition_version as u32)
+            Ok(WorkflowInstance::from_db(WorkflowInstanceRecord {
+               id: WorkflowInstanceId::from_uuid(row.id),
+               tenant_id: TenantId::from_uuid(row.tenant_id),
+               definition_id: WorkflowDefinitionId::from_uuid(row.definition_id),
+               definition_version: Version::new(row.definition_version as u32)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               DisplayNumber::try_from(row.display_number)
+               display_number: DisplayNumber::try_from(row.display_number)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               row.title,
-               row.form_data,
-               row.status
+               title: row.title,
+               form_data: row.form_data,
+               status: row
+                  .status
                   .parse::<WorkflowInstanceStatus>()
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               Version::new(row.version as u32)
+               version: Version::new(row.version as u32)
                   .map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               row.current_step_id,
-               UserId::from_uuid(row.initiated_by),
-               row.submitted_at,
-               row.completed_at,
-               row.created_at,
-               row.updated_at,
-            ))
+               current_step_id: row.current_step_id,
+               initiated_by: UserId::from_uuid(row.initiated_by),
+               submitted_at: row.submitted_at,
+               completed_at: row.completed_at,
+               created_at: row.created_at,
+               updated_at: row.updated_at,
+            }))
          })
          .collect::<Result<Vec<_>, InfraError>>()?;
 

--- a/backend/crates/infra/src/repository/workflow_step_repository.rs
+++ b/backend/crates/infra/src/repository/workflow_step_repository.rs
@@ -9,7 +9,14 @@ use ringiflow_domain::{
    tenant::TenantId,
    user::UserId,
    value_objects::Version,
-   workflow::{StepDecision, WorkflowInstanceId, WorkflowStep, WorkflowStepId, WorkflowStepStatus},
+   workflow::{
+      StepDecision,
+      WorkflowInstanceId,
+      WorkflowStep,
+      WorkflowStepId,
+      WorkflowStepRecord,
+      WorkflowStepStatus,
+   },
 };
 use sqlx::PgPool;
 
@@ -165,28 +172,30 @@ impl WorkflowStepRepository for PostgresWorkflowStepRepository {
          return Ok(None);
       };
 
-      let step = WorkflowStep::from_db(
-         WorkflowStepId::from_uuid(r.id),
-         WorkflowInstanceId::from_uuid(r.instance_id),
-         r.step_id,
-         r.step_name,
-         r.step_type,
-         WorkflowStepStatus::from_str(&r.status)
+      let step = WorkflowStep::from_db(WorkflowStepRecord {
+         id:           WorkflowStepId::from_uuid(r.id),
+         instance_id:  WorkflowInstanceId::from_uuid(r.instance_id),
+         step_id:      r.step_id,
+         step_name:    r.step_name,
+         step_type:    r.step_type,
+         status:       WorkflowStepStatus::from_str(&r.status)
             .map_err(|e| InfraError::Unexpected(format!("不正なステータス: {}", e)))?,
-         Version::new(r.version as u32).map_err(|e| InfraError::Unexpected(e.to_string()))?,
-         r.assigned_to.map(UserId::from_uuid),
-         r.decision
+         version:      Version::new(r.version as u32)
+            .map_err(|e| InfraError::Unexpected(e.to_string()))?,
+         assigned_to:  r.assigned_to.map(UserId::from_uuid),
+         decision:     r
+            .decision
             .as_deref()
             .map(StepDecision::from_str)
             .transpose()
             .map_err(|e| InfraError::Unexpected(format!("不正な判断: {}", e)))?,
-         r.comment,
-         r.due_date,
-         r.started_at,
-         r.completed_at,
-         r.created_at,
-         r.updated_at,
-      );
+         comment:      r.comment,
+         due_date:     r.due_date,
+         started_at:   r.started_at,
+         completed_at: r.completed_at,
+         created_at:   r.created_at,
+         updated_at:   r.updated_at,
+      });
 
       Ok(Some(step))
    }
@@ -217,28 +226,30 @@ impl WorkflowStepRepository for PostgresWorkflowStepRepository {
       rows
          .into_iter()
          .map(|r| -> Result<WorkflowStep, InfraError> {
-            Ok(WorkflowStep::from_db(
-               WorkflowStepId::from_uuid(r.id),
-               WorkflowInstanceId::from_uuid(r.instance_id),
-               r.step_id,
-               r.step_name,
-               r.step_type,
-               WorkflowStepStatus::from_str(&r.status)
+            Ok(WorkflowStep::from_db(WorkflowStepRecord {
+               id:           WorkflowStepId::from_uuid(r.id),
+               instance_id:  WorkflowInstanceId::from_uuid(r.instance_id),
+               step_id:      r.step_id,
+               step_name:    r.step_name,
+               step_type:    r.step_type,
+               status:       WorkflowStepStatus::from_str(&r.status)
                   .map_err(|e| InfraError::Unexpected(format!("不正なステータス: {}", e)))?,
-               Version::new(r.version as u32).map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               r.assigned_to.map(UserId::from_uuid),
-               r.decision
+               version:      Version::new(r.version as u32)
+                  .map_err(|e| InfraError::Unexpected(e.to_string()))?,
+               assigned_to:  r.assigned_to.map(UserId::from_uuid),
+               decision:     r
+                  .decision
                   .as_deref()
                   .map(StepDecision::from_str)
                   .transpose()
                   .map_err(|e| InfraError::Unexpected(format!("不正な判断: {}", e)))?,
-               r.comment,
-               r.due_date,
-               r.started_at,
-               r.completed_at,
-               r.created_at,
-               r.updated_at,
-            ))
+               comment:      r.comment,
+               due_date:     r.due_date,
+               started_at:   r.started_at,
+               completed_at: r.completed_at,
+               created_at:   r.created_at,
+               updated_at:   r.updated_at,
+            }))
          })
          .collect()
    }
@@ -269,28 +280,30 @@ impl WorkflowStepRepository for PostgresWorkflowStepRepository {
       rows
          .into_iter()
          .map(|r| -> Result<WorkflowStep, InfraError> {
-            Ok(WorkflowStep::from_db(
-               WorkflowStepId::from_uuid(r.id),
-               WorkflowInstanceId::from_uuid(r.instance_id),
-               r.step_id,
-               r.step_name,
-               r.step_type,
-               WorkflowStepStatus::from_str(&r.status)
+            Ok(WorkflowStep::from_db(WorkflowStepRecord {
+               id:           WorkflowStepId::from_uuid(r.id),
+               instance_id:  WorkflowInstanceId::from_uuid(r.instance_id),
+               step_id:      r.step_id,
+               step_name:    r.step_name,
+               step_type:    r.step_type,
+               status:       WorkflowStepStatus::from_str(&r.status)
                   .map_err(|e| InfraError::Unexpected(format!("不正なステータス: {}", e)))?,
-               Version::new(r.version as u32).map_err(|e| InfraError::Unexpected(e.to_string()))?,
-               r.assigned_to.map(UserId::from_uuid),
-               r.decision
+               version:      Version::new(r.version as u32)
+                  .map_err(|e| InfraError::Unexpected(e.to_string()))?,
+               assigned_to:  r.assigned_to.map(UserId::from_uuid),
+               decision:     r
+                  .decision
                   .as_deref()
                   .map(StepDecision::from_str)
                   .transpose()
                   .map_err(|e| InfraError::Unexpected(format!("不正な判断: {}", e)))?,
-               r.comment,
-               r.due_date,
-               r.started_at,
-               r.completed_at,
-               r.created_at,
-               r.updated_at,
-            ))
+               comment:      r.comment,
+               due_date:     r.due_date,
+               started_at:   r.started_at,
+               completed_at: r.completed_at,
+               created_at:   r.created_at,
+               updated_at:   r.updated_at,
+            }))
          })
          .collect()
    }

--- a/backend/crates/infra/tests/workflow_instance_repository_test.rs
+++ b/backend/crates/infra/tests/workflow_instance_repository_test.rs
@@ -16,7 +16,7 @@ use ringiflow_domain::{
    tenant::TenantId,
    user::UserId,
    value_objects::{DisplayNumber, Version},
-   workflow::{WorkflowDefinitionId, WorkflowInstance, WorkflowInstanceId},
+   workflow::{NewWorkflowInstance, WorkflowDefinitionId, WorkflowInstance, WorkflowInstanceId},
 };
 use ringiflow_infra::repository::{PostgresWorkflowInstanceRepository, WorkflowInstanceRepository};
 use serde_json::json;
@@ -31,17 +31,17 @@ async fn test_insert_で新規インスタンスを作成できる(pool: PgPool)
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({"field": "value"}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({"field": "value"}),
+      initiated_by: user_id,
       now,
-   );
+   });
 
    let result = repo.insert(&instance).await;
 
@@ -57,17 +57,17 @@ async fn test_find_by_id_でインスタンスを取得できる(pool: PgPool) {
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({"field": "value"}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({"field": "value"}),
+      initiated_by: user_id,
       now,
-   );
+   });
    let instance_id = instance.id().clone();
 
    repo.insert(&instance).await.unwrap();
@@ -104,28 +104,28 @@ async fn test_find_by_tenant_テナント内の一覧を取得できる(pool: Pg
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // 2つのインスタンスを作成
-   let instance1 = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
-      definition_id.clone(),
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "申請1".to_string(),
-      json!({}),
-      user_id.clone(),
+   let instance1 = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
+      definition_id: definition_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "申請1".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
-   let instance2 = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   });
+   let instance2 = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(101).unwrap(),
-      "申請2".to_string(),
-      json!({}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(101).unwrap(),
+      title: "申請2".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id,
       now,
-   );
+   });
 
    repo.insert(&instance1).await.unwrap();
    repo.insert(&instance2).await.unwrap();
@@ -162,17 +162,17 @@ async fn test_find_by_initiated_by_申請者によるインスタンスを取得
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "自分の申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "自分の申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
 
    repo.insert(&instance).await.unwrap();
 
@@ -192,17 +192,17 @@ async fn test_update_with_version_check_バージョン一致で更新できる(
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id,
       now,
-   );
+   });
    let instance_id = instance.id().clone();
    let expected_version = instance.version();
 
@@ -239,17 +239,17 @@ async fn test_update_with_version_check_バージョン不一致でconflictエ�
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id,
       now,
-   );
+   });
 
    // INSERT で保存
    repo.insert(&instance).await.unwrap();
@@ -294,28 +294,28 @@ async fn test_find_by_ids_存在するidを渡すとインスタンスが返る(
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance1 = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
-      definition_id.clone(),
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "申請1".to_string(),
-      json!({}),
-      user_id.clone(),
+   let instance1 = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
+      definition_id: definition_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "申請1".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
-   let instance2 = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   });
+   let instance2 = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(101).unwrap(),
-      "申請2".to_string(),
-      json!({}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(101).unwrap(),
+      title: "申請2".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id,
       now,
-   );
+   });
    let id1 = instance1.id().clone();
    let id2 = instance2.id().clone();
 
@@ -346,17 +346,17 @@ async fn test_find_by_ids_存在しないidを含んでも存在するものの�
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id,
       now,
-   );
+   });
    let existing_id = instance.id().clone();
    let nonexistent_id = WorkflowInstanceId::new();
 
@@ -382,17 +382,17 @@ async fn test_find_by_ids_テナントidでフィルタされる(pool: PgPool) {
    let user_id = UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id,
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id,
       now,
-   );
+   });
    let instance_id = instance.id().clone();
 
    repo.insert(&instance).await.unwrap();

--- a/backend/crates/infra/tests/workflow_step_repository_test.rs
+++ b/backend/crates/infra/tests/workflow_step_repository_test.rs
@@ -15,6 +15,8 @@ use ringiflow_domain::{
    user::UserId,
    value_objects::{DisplayNumber, Version},
    workflow::{
+      NewWorkflowInstance,
+      NewWorkflowStep,
       StepDecision,
       WorkflowDefinitionId,
       WorkflowInstance,
@@ -44,29 +46,29 @@ async fn test_insert_で新規ステップを作成できる(pool: PgPool) {
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    instance_repo.insert(&instance).await.unwrap();
 
    // ステップを作成
-   let step = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance.id().clone(),
-      "step1".to_string(),
-      "承認".to_string(),
-      "approval".to_string(),
-      Some(user_id),
+   let step = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance.id().clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id),
       now,
-   );
+   });
 
    let result = step_repo.insert(&step).await;
 
@@ -85,29 +87,29 @@ async fn test_find_by_id_でステップを取得できる(pool: PgPool) {
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    instance_repo.insert(&instance).await.unwrap();
 
    // ステップを作成
-   let step = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance.id().clone(),
-      "step1".to_string(),
-      "承認".to_string(),
-      "approval".to_string(),
-      Some(user_id),
+   let step = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance.id().clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id),
       now,
-   );
+   });
    let step_id = step.id().clone();
    step_repo.insert(&step).await.unwrap();
 
@@ -150,39 +152,39 @@ async fn test_find_by_instance_インスタンスのステップ一覧を取得�
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    let instance_id = instance.id().clone();
    instance_repo.insert(&instance).await.unwrap();
 
    // 複数のステップを作成
-   let step1 = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance_id.clone(),
-      "step1".to_string(),
-      "承認1".to_string(),
-      "approval".to_string(),
-      Some(user_id.clone()),
+   let step1 = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance_id.clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認1".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id.clone()),
       now,
-   );
-   let step2 = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance_id.clone(),
-      "step2".to_string(),
-      "承認2".to_string(),
-      "approval".to_string(),
-      Some(user_id),
+   });
+   let step2 = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance_id.clone(),
+      step_id: "step2".to_string(),
+      step_name: "承認2".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id),
       now,
-   );
+   });
    step_repo.insert(&step1).await.unwrap();
    step_repo.insert(&step2).await.unwrap();
 
@@ -222,29 +224,29 @@ async fn test_find_by_assigned_to_担当者のタスク一覧を取得できる(
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    instance_repo.insert(&instance).await.unwrap();
 
    // ステップを作成
-   let step = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance.id().clone(),
-      "step1".to_string(),
-      "承認".to_string(),
-      "approval".to_string(),
-      Some(user_id.clone()),
+   let step = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance.id().clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id.clone()),
       now,
-   );
+   });
    step_repo.insert(&step).await.unwrap();
 
    // 検索
@@ -267,29 +269,29 @@ async fn test_update_with_version_check_バージョン一致で更新できる(
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    instance_repo.insert(&instance).await.unwrap();
 
    // ステップを作成して INSERT
-   let step = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance.id().clone(),
-      "step1".to_string(),
-      "承認".to_string(),
-      "approval".to_string(),
-      Some(user_id),
+   let step = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance.id().clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id),
       now,
-   );
+   });
    let step_id = step.id().clone();
    let expected_version = step.version();
    step_repo.insert(&step).await.unwrap();
@@ -327,29 +329,29 @@ async fn test_update_with_version_check_バージョン不一致でconflictエ�
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    instance_repo.insert(&instance).await.unwrap();
 
    // ステップを作成して INSERT
-   let step = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance.id().clone(),
-      "step1".to_string(),
-      "承認".to_string(),
-      "approval".to_string(),
-      Some(user_id),
+   let step = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance.id().clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id),
       now,
-   );
+   });
    step_repo.insert(&step).await.unwrap();
 
    // アクティブ化（バージョンインクリメント）
@@ -382,29 +384,29 @@ async fn test_ステップを完了できる(pool: PgPool) {
    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
    // インスタンスを作成
-   let instance = WorkflowInstance::new(
-      WorkflowInstanceId::new(),
-      tenant_id.clone(),
+   let instance = WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: tenant_id.clone(),
       definition_id,
-      Version::initial(),
-      DisplayNumber::new(100).unwrap(),
-      "テスト申請".to_string(),
-      json!({}),
-      user_id.clone(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(100).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: user_id.clone(),
       now,
-   );
+   });
    instance_repo.insert(&instance).await.unwrap();
 
    // ステップを作成
-   let step = WorkflowStep::new(
-      WorkflowStepId::new(),
-      instance.id().clone(),
-      "step1".to_string(),
-      "承認".to_string(),
-      "approval".to_string(),
-      Some(user_id),
+   let step = WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance.id().clone(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(user_id),
       now,
-   );
+   });
    let step_id = step.id().clone();
    let v1 = step.version();
    step_repo.insert(&step).await.unwrap();


### PR DESCRIPTION
## Issue

Related to #222

## 概要

`id` と `now` の外部注入（#228）により増加した引数を、パラメータ構造体で整理するリファクタリング。

## 変更内容

- **6つのパラメータ構造体を導入** — 位置引数をすべて名前付きフィールドに置換
  - `NewWorkflowDefinition` / `WorkflowDefinitionRecord`
  - `NewWorkflowInstance` / `WorkflowInstanceRecord`
  - `NewWorkflowStep` / `WorkflowStepRecord`
- **`#[allow(clippy::too_many_arguments)]` をすべて除去**
- `new` → `New*` 構造体（エンティティ新規作成）
- `from_db` → `*Record` 構造体（DB 復元）

### 引数削減の効果

| 関数 | Before | After |
|------|--------|-------|
| `WorkflowInstance::new` | 9 args | 1 (struct) |
| `WorkflowInstance::from_db` | 15 args | 1 (struct) |
| `WorkflowStep::new` | 7 args | 1 (struct) |
| `WorkflowStep::from_db` | 15 args | 1 (struct) |
| `WorkflowDefinition::new` | 7 args | 1 (struct) |
| `WorkflowDefinition::from_db` | 10 args | 1 (struct) |

### `FromRow` を採用しなかった理由

`from_db` に `sqlx::FromRow` derive を検討したが、domain クレートが sqlx に依存することになりレイヤー分離が崩れるため、パラメータ構造体で統一した。

## 変更ファイル

- `backend/crates/domain/src/workflow.rs` — 構造体定義 + `new`/`from_db` シグネチャ変更
- `backend/crates/infra/src/repository/` — `from_db` 呼び出し元（3ファイル）
- `backend/apps/core-service/src/usecase/` — `new` 呼び出し元（3ファイル）
- `backend/crates/infra/tests/` — テスト内の `new` 呼び出し（2ファイル）

## Test plan

- `just check` 通過（lint + clippy + 全テスト + sqlx prepare check）

🤖 Generated with [Claude Code](https://claude.com/claude-code)