### PR TITLE
#258 Introduce cargo-watch for backend hot reloading

### DIFF
--- a/docs/04_手順書/01_開発参画/01_開発環境構築.md
+++ b/docs/04_手順書/01_開発参画/01_開発環境構築.md
@@ -20,6 +20,7 @@ RingiFlow の開発に必要なツールをインストールする。
 | タスクランナー | just | 最新 | 開発タスク実行 |
 | データベース | sqlx-cli | 最新 | マイグレーション管理 |
 | Git フック | lefthook | 最新 | コミット時の自動処理 |
+| ファイルウォッチ | cargo-watch | 最新 | バックエンドのホットリロード（自動リビルド） |
 | プロセスマネージャー | mprocs | 最新 | 開発サーバー一括起動 |
 | リンター | ShellCheck | 最新 | シェルスクリプト静的解析 |
 | E2E テスト | hurl | 最新 | HTTP API テスト |
@@ -238,13 +239,34 @@ just --version
 
 ---
 
-## 6. mprocs のインストール
+## 6. cargo-watch のインストール
+
+Cargo のサブコマンドとして動作するファイルウォッチツール。ソースコードの変更を検知し、自動でリビルド＆再起動する。`just dev-bff` 等の開発サーバー起動で使用する。
+
+公式: https://github.com/watchexec/cargo-watch
+
+### 6.1 Cargo でインストール
+
+```bash
+cargo install cargo-watch
+```
+
+### 6.2 バージョン確認
+
+```bash
+cargo watch --version
+# 出力例: cargo-watch 8.x.x
+```
+
+---
+
+## 7. mprocs のインストール
 
 TUI（テキストユーザーインターフェース）プロセスマネージャー。`just dev-all` で全開発サーバーを一括起動する際に使用する。
 
 公式: https://github.com/pvolok/mprocs
 
-### 6.1 インストール方法（いずれか）
+### 7.1 インストール方法（いずれか）
 
 ```bash
 # Cargo
@@ -257,7 +279,7 @@ brew install mprocs
 mise use -g mprocs
 ```
 
-### 6.2 バージョン確認
+### 7.2 バージョン確認
 
 ```bash
 mprocs --version
@@ -266,7 +288,7 @@ mprocs --version
 
 ---
 
-## 7. sqlx-cli のインストール
+## 8. sqlx-cli のインストール
 
 SQLx 用の CLI ツール。データベースマイグレーションの実行やコンパイル時クエリ検証に使用する。
 
@@ -274,13 +296,13 @@ SQLx 用の CLI ツール。データベースマイグレーションの実行�
 
 詳細は [sqlx-cli ナレッジベース](../../06_ナレッジベース/rust/sqlx-cli.md) を参照。
 
-### 7.1 Cargo でインストール
+### 8.1 Cargo でインストール
 
 ```bash
 cargo install sqlx-cli --no-default-features --features rustls,postgres
 ```
 
-### 7.2 バージョン確認
+### 8.2 バージョン確認
 
 ```bash
 cargo sqlx --version
@@ -289,13 +311,13 @@ cargo sqlx --version
 
 ---
 
-## 8. lefthook のインストール
+## 9. lefthook のインストール
 
 Git フック管理ツール。コミット時に Issue 番号を自動付与する。
 
 公式: https://github.com/evilmartians/lefthook
 
-### 8.1 インストール方法（いずれか）
+### 9.1 インストール方法（いずれか）
 
 ```bash
 # mise
@@ -311,7 +333,7 @@ go install github.com/evilmartians/lefthook@latest
 npm install -g lefthook
 ```
 
-### 8.2 バージョン確認
+### 9.2 バージョン確認
 
 ```bash
 lefthook --version
@@ -320,13 +342,13 @@ lefthook --version
 
 ---
 
-## 9. ShellCheck のインストール
+## 10. ShellCheck のインストール
 
 シェルスクリプトの静的解析ツール。構文エラーやバグを検出する。
 
 公式: https://www.shellcheck.net/
 
-### 9.1 インストール方法（いずれか）
+### 10.1 インストール方法（いずれか）
 
 ```bash
 # mise
@@ -342,7 +364,7 @@ brew install shellcheck
 cabal update && cabal install ShellCheck
 ```
 
-### 9.2 バージョン確認
+### 10.2 バージョン確認
 
 ```bash
 shellcheck --version
@@ -352,13 +374,13 @@ shellcheck --version
 
 ---
 
-## 10. hurl のインストール
+## 11. hurl のインストール
 
 HTTP API テストツール。curl に似た構文でリクエストとアサーションを記述でき、E2E テストに使用する。
 
 公式: https://hurl.dev/
 
-### 10.1 インストール方法（いずれか）
+### 11.1 インストール方法（いずれか）
 
 ```bash
 # mise
@@ -374,7 +396,7 @@ brew install hurl
 sudo apt install hurl
 ```
 
-### 10.2 バージョン確認
+### 11.2 バージョン確認
 
 ```bash
 hurl --version
@@ -383,13 +405,13 @@ hurl --version
 
 ---
 
-## 11. actionlint のインストール
+## 12. actionlint のインストール
 
 GitHub Actions ワークフローの静的解析ツール。YAML の構文エラー、未定義の変数参照、セキュリティ問題を検出する。内部で shellcheck を使用し、`run:` ブロック内のシェルスクリプトもチェックする。
 
 公式: https://github.com/rhysd/actionlint
 
-### 11.1 インストール方法（いずれか）
+### 12.1 インストール方法（いずれか）
 
 ```bash
 # mise
@@ -402,7 +424,7 @@ brew install actionlint
 go install github.com/rhysd/actionlint/cmd/actionlint@latest
 ```
 
-### 11.2 バージョン確認
+### 12.2 バージョン確認
 
 ```bash
 actionlint --version
@@ -411,13 +433,13 @@ actionlint --version
 
 ---
 
-## 12. GitHub CLI (gh) のインストール
+## 13. GitHub CLI (gh) のインストール
 
 GitHub の Issue、PR、ラベル、Projects を CLI から操作するツール。Issue 駆動開発で多用する。
 
 公式: https://cli.github.com/
 
-### 12.1 インストール方法（いずれか）
+### 13.1 インストール方法（いずれか）
 
 ```bash
 # mise
@@ -433,21 +455,21 @@ sudo apt install gh
 winget install GitHub.cli
 ```
 
-### 12.2 バージョン確認
+### 13.2 バージョン確認
 
 ```bash
 gh --version
 # 出力例: gh version 2.x.x
 ```
 
-### 12.3 認証
+### 13.3 認証
 
 ```bash
 gh auth login
 # ブラウザで認証、または Token を入力
 ```
 
-### 12.4 認証確認
+### 13.4 認証確認
 
 ```bash
 gh auth status
@@ -456,13 +478,13 @@ gh auth status
 
 ---
 
-## 13. psql のインストール
+## 14. psql のインストール
 
 PostgreSQL のコマンドラインクライアント。`just db-tables`、`just db-schema`、`just db-query` で使用する。
 
 公式: https://www.postgresql.org/
 
-### 13.1 インストール方法（いずれか）
+### 14.1 インストール方法（いずれか）
 
 ```bash
 # Fedora
@@ -480,7 +502,7 @@ sudo pacman -S postgresql-libs
 
 注意: PostgreSQL サーバーは Docker で起動するため、クライアント（psql）のみインストールすれば十分。
 
-### 13.2 バージョン確認
+### 14.2 バージョン確認
 
 ```bash
 psql --version
@@ -489,13 +511,13 @@ psql --version
 
 ---
 
-## 14. redis-cli のインストール
+## 15. redis-cli のインストール
 
 Redis のコマンドラインクライアント。`just redis-keys`、`just redis-get` で使用する。
 
 公式: https://redis.io/
 
-### 14.1 インストール方法（いずれか）
+### 15.1 インストール方法（いずれか）
 
 ```bash
 # Fedora
@@ -513,7 +535,7 @@ sudo pacman -S redis
 
 注意: Redis サーバーは Docker で起動するため、クライアント（redis-cli）のみインストールすれば十分。
 
-### 14.2 バージョン確認
+### 15.2 バージョン確認
 
 ```bash
 redis-cli --version
@@ -522,7 +544,7 @@ redis-cli --version
 
 ---
 
-## 15. 全ツールの確認
+## 16. 全ツールの確認
 
 以下のコマンドをすべて実行し、エラーがないことを確認する:
 
@@ -538,6 +560,9 @@ docker --version && docker compose version
 
 # タスクランナー
 just --version
+
+# ファイルウォッチ（バックエンドホットリロード）
+cargo watch --version
 
 # プロセスマネージャー
 mprocs --version
@@ -576,9 +601,9 @@ just check-tools
 
 ---
 
-## 16. IDE 設定（推奨）
+## 17. IDE 設定（推奨）
 
-### 14.1 VS Code 推奨拡張機能
+### 17.1 VS Code 推奨拡張機能
 
 `.vscode/extensions.json`:
 
@@ -596,7 +621,7 @@ just check-tools
 }
 ```
 
-### 14.2 VS Code 設定
+### 17.2 VS Code 設定
 
 `.vscode/settings.json`:
 
@@ -614,7 +639,7 @@ just check-tools
 }
 ```
 
-### 14.3 IntelliJ IDEA / WebStorm 設定
+### 17.3 IntelliJ IDEA / WebStorm 設定
 
 #### Elm プラグインのインストール
 
@@ -767,6 +792,7 @@ rm -f .idea/elm.xml
 
 | 日付 | 変更内容 | 担当 |
 |------|---------|------|
+| 2026-02-06 | cargo-watch のインストール手順を追加（バックエンドホットリロード） | - |
 | 2026-01-31 | psql / redis-cli のインストール手順を追加（データストア操作用） | - |
 | 2026-01-28 | mprocs のインストール手順を追加（開発サーバー一括起動） | - |
 | 2026-01-27 | GitHub CLI (gh) のインストール手順を追加 | - |

--- a/justfile
+++ b/justfile
@@ -39,6 +39,7 @@ check-tools:
     @which shellcheck > /dev/null || (echo "ERROR: shellcheck がインストールされていません" && exit 1)
     @which hurl > /dev/null || (echo "ERROR: hurl がインストールされていません" && exit 1)
     @which actionlint > /dev/null || (echo "ERROR: actionlint がインストールされていません" && exit 1)
+    @which cargo-watch > /dev/null || (echo "ERROR: cargo-watch がインストールされていません" && exit 1)
     @which mprocs > /dev/null || (echo "ERROR: mprocs がインストールされていません" && exit 1)
     @which gh > /dev/null || (echo "ERROR: GitHub CLI (gh) がインストールされていません" && exit 1)
     @which psql > /dev/null || (echo "ERROR: psql がインストールされていません" && exit 1)
@@ -115,17 +116,17 @@ dev-deps:
     echo "Redis: localhost:${REDIS_PORT}"
     echo "プロジェクト名: $PROJECT_NAME"
 
-# BFF 開発サーバーを起動（ポート: $BFF_PORT）
+# BFF 開発サーバーを起動（ポート: $BFF_PORT、ファイル変更で自動リビルド）
 dev-bff:
-    cd backend && cargo run -p ringiflow-bff
+    cd backend && cargo watch -x 'run -p ringiflow-bff'
 
-# Core Service 開発サーバーを起動（ポート: $CORE_PORT）
+# Core Service 開発サーバーを起動（ポート: $CORE_PORT、ファイル変更で自動リビルド）
 dev-core-service:
-    cd backend && cargo run -p ringiflow-core-service
+    cd backend && cargo watch -x 'run -p ringiflow-core-service'
 
-# Auth Service 開発サーバーを起動（ポート: $AUTH_PORT）
+# Auth Service 開発サーバーを起動（ポート: $AUTH_PORT、ファイル変更で自動リビルド）
 dev-auth-service:
-    cd backend && cargo run -p ringiflow-auth-service
+    cd backend && cargo watch -x 'run -p ringiflow-auth-service'
 
 # フロントエンド開発サーバーを起動
 dev-web:


### PR DESCRIPTION
## Issue

Closes #258

## Summary

バックエンドの開発サーバー（BFF / Core Service / Auth Service）に cargo-watch を導入し、ファイル変更時の自動リビルド＆再起動を実現する。

## Changes

- justfile: `cargo run` → `cargo watch -x 'run -p ...'` に変更（dev-bff / dev-core-service / dev-auth-service）
- justfile: `check-tools` に `cargo-watch` の確認を追加
- 開発環境構築手順書: cargo-watch のインストールセクションを追加

## Test plan

- [x] `just check-tools` が通ること（cargo-watch の存在確認を含む）
- [x] justfile の dev-bff / dev-core-service / dev-auth-service が `cargo watch` を使用していること

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 既存パターン整合 | OK | 他のツール（mprocs 等）と同じ形式で check-tools に追加、手順書のセクション構造を踏襲 |
| 2 | ドキュメント整合 | OK | 概要テーブル、インストールセクション、全ツール確認セクション、変更履歴を更新 |
| 3 | セクション番号の連番 | OK | 新セクション 6 の挿入に伴い 7〜17 まで正しくリナンバリング |

🤖 Generated with [Claude Code](https://claude.com/claude-code)