### PR TITLE
#184 Consolidate test fixtures into shared common module

### DIFF
--- a/backend/crates/infra/tests/common/mod.rs
+++ b/backend/crates/infra/tests/common/mod.rs
@@ -1,0 +1,135 @@
+//! テスト共通フィクスチャ
+//!
+//! DB を使用する統合テストで共通利用するシードデータ定数・エンティティ生成ヘルパー。
+//! Rust の統合テスト規約に従い `tests/common/mod.rs` に配置。
+
+// 各テストファイルが独立したクレートとしてコンパイルされるため、
+// 使用しない関数に dead_code 警告が出る。モジュール全体で抑制する。
+#![allow(dead_code)]
+
+use chrono::{DateTime, Utc};
+use ringiflow_domain::{
+   tenant::TenantId,
+   user::UserId,
+   value_objects::{DisplayNumber, Version},
+   workflow::{
+      NewWorkflowInstance,
+      NewWorkflowStep,
+      WorkflowDefinitionId,
+      WorkflowInstance,
+      WorkflowInstanceId,
+      WorkflowStep,
+      WorkflowStepId,
+   },
+};
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+// =============================================================================
+// シードデータ定数
+// =============================================================================
+
+/// シードデータのテナント ID
+pub fn seed_tenant_id() -> TenantId {
+   TenantId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap())
+}
+
+/// シードデータのユーザー ID
+pub fn seed_user_id() -> UserId {
+   UserId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap())
+}
+
+/// シードデータのワークフロー定義 ID
+pub fn seed_definition_id() -> WorkflowDefinitionId {
+   WorkflowDefinitionId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap())
+}
+
+/// テスト用の固定日時
+pub fn test_now() -> DateTime<Utc> {
+   DateTime::from_timestamp(1_700_000_000, 0).unwrap()
+}
+
+// =============================================================================
+// エンティティ生成ヘルパー
+// =============================================================================
+
+/// デフォルト値で WorkflowInstance を作成
+pub fn create_test_instance(display_number: i64) -> WorkflowInstance {
+   WorkflowInstance::new(NewWorkflowInstance {
+      id: WorkflowInstanceId::new(),
+      tenant_id: seed_tenant_id(),
+      definition_id: seed_definition_id(),
+      definition_version: Version::initial(),
+      display_number: DisplayNumber::new(display_number).unwrap(),
+      title: "テスト申請".to_string(),
+      form_data: json!({}),
+      initiated_by: seed_user_id(),
+      now: test_now(),
+   })
+}
+
+/// デフォルト値で WorkflowStep を作成
+pub fn create_test_step(instance_id: &WorkflowInstanceId, display_number: i64) -> WorkflowStep {
+   WorkflowStep::new(NewWorkflowStep {
+      id: WorkflowStepId::new(),
+      instance_id: instance_id.clone(),
+      display_number: DisplayNumber::new(display_number).unwrap(),
+      step_id: "step1".to_string(),
+      step_name: "承認".to_string(),
+      step_type: "approval".to_string(),
+      assigned_to: Some(seed_user_id()),
+      now: test_now(),
+   })
+}
+
+// =============================================================================
+// DB セットアップヘルパー
+// =============================================================================
+
+/// テスト用のテナントとユーザーを DB に作成
+pub async fn setup_test_data(pool: &PgPool) -> (TenantId, UserId) {
+   let tenant_id = TenantId::from_uuid(Uuid::now_v7());
+   let user_id = UserId::from_uuid(Uuid::now_v7());
+
+   // テナント作成
+   sqlx::query!(
+      r#"
+        INSERT INTO tenants (id, name, subdomain, plan, status)
+        VALUES ($1, 'Test Tenant', 'test', 'free', 'active')
+        "#,
+      tenant_id.as_uuid()
+   )
+   .execute(pool)
+   .await
+   .expect("テナント作成に失敗");
+
+   // ユーザー作成
+   sqlx::query!(
+      r#"
+        INSERT INTO users (id, tenant_id, display_number, email, name, status)
+        VALUES ($1, $2, 1, 'test@example.com', 'Test User', 'active')
+        "#,
+      user_id.as_uuid(),
+      tenant_id.as_uuid()
+   )
+   .execute(pool)
+   .await
+   .expect("ユーザー作成に失敗");
+
+   (tenant_id, user_id)
+}
+
+/// ロールをユーザーに割り当て
+pub async fn assign_role(pool: &PgPool, user_id: &UserId) {
+   sqlx::query!(
+      r#"
+        INSERT INTO user_roles (user_id, role_id)
+        SELECT $1, id FROM roles WHERE name = 'user' AND is_system = true
+        "#,
+      user_id.as_uuid()
+   )
+   .execute(pool)
+   .await
+   .expect("ロール割り当てに失敗");
+}

--- a/backend/crates/infra/tests/display_id_counter_repository_test.rs
+++ b/backend/crates/infra/tests/display_id_counter_repository_test.rs
@@ -9,6 +9,9 @@
 //! cd backend && cargo test -p ringiflow-infra --test display_id_counter_repository_test
 //! ```
 
+mod common;
+
+use common::seed_tenant_id;
 use ringiflow_domain::{
    tenant::TenantId,
    value_objects::{DisplayIdEntityType, DisplayNumber},
@@ -36,7 +39,7 @@ async fn insert_counter(pool: &PgPool, tenant_id: &TenantId, entity_type: &str, 
 #[sqlx::test(migrations = "../../migrations")]
 async fn test_初回採番で1を返す(pool: PgPool) {
    let repo = PostgresDisplayIdCounterRepository::new(pool.clone());
-   let tenant_id = TenantId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
+   let tenant_id = seed_tenant_id();
 
    // workflow_step のカウンターを初期化（last_number=0）
    insert_counter(
@@ -57,7 +60,7 @@ async fn test_初回採番で1を返す(pool: PgPool) {
 #[sqlx::test(migrations = "../../migrations")]
 async fn test_連続採番で連番を返す(pool: PgPool) {
    let repo = PostgresDisplayIdCounterRepository::new(pool.clone());
-   let tenant_id = TenantId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
+   let tenant_id = seed_tenant_id();
 
    // workflow_step のカウンターを初期化（last_number=0）
    insert_counter(
@@ -89,7 +92,7 @@ async fn test_連続採番で連番を返す(pool: PgPool) {
 #[sqlx::test(migrations = "../../migrations")]
 async fn test_異なるエンティティ型は独立して採番される(pool: PgPool) {
    let repo = PostgresDisplayIdCounterRepository::new(pool.clone());
-   let tenant_id = TenantId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
+   let tenant_id = seed_tenant_id();
 
    // workflow_step のカウンターを初期化（last_number=0）
    // workflow_instance はマイグレーションで既に初期化済み

--- a/backend/crates/infra/tests/workflow_definition_repository_test.rs
+++ b/backend/crates/infra/tests/workflow_definition_repository_test.rs
@@ -9,6 +9,9 @@
 //! cd backend && cargo test -p ringiflow-infra --test workflow_definition_repository_test
 //! ```
 
+mod common;
+
+use common::{seed_definition_id, seed_tenant_id};
 use ringiflow_domain::{tenant::TenantId, workflow::WorkflowDefinitionId};
 use ringiflow_infra::repository::{
    PostgresWorkflowDefinitionRepository,
@@ -19,7 +22,7 @@ use sqlx::PgPool;
 #[sqlx::test(migrations = "../../migrations")]
 async fn test_find_published_by_tenant_returns_published_definitions(pool: PgPool) {
    let repo = PostgresWorkflowDefinitionRepository::new(pool);
-   let tenant_id = TenantId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
+   let tenant_id = seed_tenant_id();
 
    let result = repo.find_published_by_tenant(&tenant_id).await;
 
@@ -43,9 +46,8 @@ async fn test_find_published_by_tenant_filters_by_tenant(pool: PgPool) {
 #[sqlx::test(migrations = "../../migrations")]
 async fn test_find_by_id_returns_definition_when_exists(pool: PgPool) {
    let repo = PostgresWorkflowDefinitionRepository::new(pool);
-   let definition_id =
-      WorkflowDefinitionId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
-   let tenant_id = TenantId::from_uuid("00000000-0000-0000-0000-000000000001".parse().unwrap());
+   let definition_id = seed_definition_id();
+   let tenant_id = seed_tenant_id();
 
    let result = repo.find_by_id(&definition_id, &tenant_id).await;
 


### PR DESCRIPTION
## Issue

Closes #184

## 概要

`backend/crates/infra/tests/` の統合テストファイル5つで重複していたテストフィクスチャを `tests/common/mod.rs` に集約した。

## 変更内容

### 新規作成
- `backend/crates/infra/tests/common/mod.rs` — 共通フィクスチャモジュール
  - シードデータ定数関数（`seed_tenant_id()`, `seed_user_id()`, `seed_definition_id()`, `test_now()`）
  - エンティティ生成ヘルパー（`create_test_instance()`, `create_test_step()`）
  - DB セットアップヘルパー（`setup_test_data()`, `assign_role()`）

### 書き換え（共通モジュール利用に変更）
- `workflow_instance_repository_test.rs`
- `workflow_step_repository_test.rs`
- `workflow_definition_repository_test.rs`
- `display_id_counter_repository_test.rs`
- `user_repository_test.rs`

### 対象外
- `session_test.rs` — Redis テスト（DB テストと異なる構造のため別スコープ）

## 効果

- 5ファイル合計で **-593行、+92行**（差分 **-501行**）
- シードデータ UUID の繰り返し（40箇所以上）を関数呼び出しに統一
- 新しいリポジトリテスト追加時のボイラープレートが大幅に削減

## Test plan

- `just check` pass（lint + 全テスト + sqlx prepare check）

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 既存パターン整合 | OK | Rust 統合テスト規約 `tests/common/mod.rs` に準拠 |
| 2 | テスト網羅性 | OK | 全72テスト（12+3+14+12+4+15+12）がパス |
| 3 | `just check` pass | OK | lint, test, sqlx prepare check すべてパス |

🤖 Generated with [Claude Code](https://claude.com/claude-code)