### PR TITLE
#287 Fix Dependabot npm directory path

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,10 +15,10 @@ updates:
       - "dependencies"
       - "rust"
 
-  # npm (Elm/Vite): apps/web の依存を管理
+  # npm (Elm/Vite): frontend の依存を管理
   # 注意: Elm パッケージ（elm.json）は Dependabot 非対応
   - package-ecosystem: "npm"
-    directory: "/apps/web"
+    directory: "/frontend"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot の npm エコシステム設定が旧パス `/apps/web` を参照していたため、正しいディレクトリ `/frontend` に修正。

## Issue

Closes #287

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 変更の正確性 | OK | directory を `/apps/web` → `/frontend` に修正、コメントも整合 |
| 2 | 影響範囲 | OK | Dependabot 設定ファイル1箇所のみ。他ファイルへの影響なし |

## Test plan

- Dependabot が次回スケジュール（月曜）で `/frontend` の `package.json` を正しくスキャンすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)