### PR TITLE
#292 Clean up stale TODO/FIXME comments

### DIFF
--- a/backend/apps/bff/src/handler/auth.rs
+++ b/backend/apps/bff/src/handler/auth.rs
@@ -104,7 +104,7 @@ impl From<UserWithPermissionsData> for MeResponseData {
          email:       res.user.email,
          name:        res.user.name,
          tenant_id:   res.user.tenant_id,
-         // TODO(#34): Core API にテナント情報取得エンドポイントを追加して取得
+         // TODO(#306): Core API にテナント情報取得エンドポイントを追加して取得
          tenant_name: "Development Tenant".to_string(),
          roles:       res.roles,
          permissions: res.permissions,

--- a/backend/apps/core-service/src/handler/auth.rs
+++ b/backend/apps/core-service/src/handler/auth.rs
@@ -19,7 +19,6 @@ use axum::{
    response::IntoResponse,
 };
 use ringiflow_domain::{
-   role::Role,
    tenant::TenantId,
    user::{Email, User, UserId},
    value_objects::{DisplayId, display_prefix},
@@ -64,27 +63,6 @@ impl From<&User> for UserResponse {
          email:     user.email().as_str().to_string(),
          name:      user.name().to_string(),
          status:    user.status().to_string(),
-      }
-   }
-}
-
-/// ロール情報レスポンス
-// FIXME: `#[allow(dead_code)]` を解消する
-//        （ユーザー取得 API でロール詳細を返すか、構造体ごと削除する）
-#[allow(dead_code)]
-#[derive(Debug, Serialize)]
-pub struct RoleResponse {
-   pub id:          Uuid,
-   pub name:        String,
-   pub permissions: Vec<String>,
-}
-
-impl From<&Role> for RoleResponse {
-   fn from(role: &Role) -> Self {
-      Self {
-         id:          *role.id().as_uuid(),
-         name:        role.name().to_string(),
-         permissions: role.permissions().iter().map(|p| p.to_string()).collect(),
       }
    }
 }

--- a/frontend/src/Shared.elm
+++ b/frontend/src/Shared.elm
@@ -113,7 +113,7 @@ withUser user shared =
 {-| テナント ID を取得
 
 MVP では固定値を返す。
-TODO: User 型に tenantId を追加後、User -> String に変更する。
+TODO(#306): User 型に tenantId を追加後、User -> String に変更する。
 
 -}
 extractTenantId : String


### PR DESCRIPTION
## Issue

Closes #292

## Summary

コードベースの TODO/FIXME コメント（10件）を精査し、対応済みのものを削除、未対応のものに正しい Issue 参照を付与した。

**変更内容:**
- `RoleResponse` 構造体と関連コード（dead code）を削除
- `TODO(#34)` を `TODO(#306)` に更新（#34 はクローズ済み）
- `Shared.elm` の TODO に `#306` の Issue 参照を追加
- 残り7件は現状のまま妥当と判断（詳細は Issue #292 の精査結果を参照）

**新規作成した Issue:**
- #306: テナント情報の取得機能を実装する

## Test plan

- [x] `just check` pass（lint + test 全通過）
- [x] `RoleResponse` 削除後にコンパイルエラーなし
- [x] elm-review pass（ReviewConfig 変更なし）

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 品質チェックリスト | OK | dead code の完全削除を確認、未使用 import も同時に削除 |
| 2 | `just check` pass | OK | lint + test 全通過 |
| 3 | Issue 参照の正確性 | OK | #34 がクローズ済みであることを `gh issue view` で確認、#306 を新規作成済み |

🤖 Generated with [Claude Code](https://claude.com/claude-code)