### PR TITLE
Upgrade Rust toolchain from 1.92.0 to 1.93.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.0
           components: clippy
 
       # rustfmt の unstable 機能を使用するため nightly が必要
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.0
 
       - name: Cache Cargo
         uses: actions/cache@v5
@@ -300,7 +300,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.93.0
 
       - name: Cache Cargo
         uses: actions/cache@v5

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RingiFlow (稟議フロー)
 
 [![CI](https://github.com/ka2kama/ringiflow/actions/workflows/ci.yaml/badge.svg)](https://github.com/ka2kama/ringiflow/actions/workflows/ci.yaml)
-![Rust](https://img.shields.io/badge/Rust-1.92-orange?logo=rust)
+![Rust](https://img.shields.io/badge/Rust-1.93-orange?logo=rust)
 ![Elm](https://img.shields.io/badge/Elm-0.19-60B5CC?logo=elm)
 ![License](https://img.shields.io/badge/License-CC0--1.0-blue)
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@
 # ============================================================
 # Stage 1: Chef（依存関係の準備）
 # ============================================================
-FROM rust:1.92-slim-bookworm AS chef
+FROM rust:1.93-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \

--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/docs/04_手順書/01_開発参画/01_開発環境構築.md
+++ b/docs/04_手順書/01_開発参画/01_開発環境構築.md
@@ -11,7 +11,7 @@ RingiFlow の開発に必要なツールをインストールする。
 
 | カテゴリ | ツール | バージョン | 用途 |
 |---------|--------|----------|------|
-| 言語 | Rust | 1.92+ | バックエンド開発 |
+| 言語 | Rust | 1.93+ | バックエンド開発 |
 | ランタイム | Node.js | 22 LTS | フロントエンドビルド |
 | パッケージマネージャー | pnpm | 最新 | フロントエンド依存管理 |
 | 言語 | Elm | 0.19.1 | フロントエンド開発（グローバル） |
@@ -58,10 +58,10 @@ source ~/.cargo/env
 
 ```bash
 rustc --version
-# 出力例: rustc 1.92.0 (xxx)
+# 出力例: rustc 1.93.0 (xxx)
 
 cargo --version
-# 出力例: cargo 1.92.0 (xxx)
+# 出力例: cargo 1.93.0 (xxx)
 ```
 
 ### 1.4 追加コンポーネントのインストール
@@ -78,7 +78,7 @@ rustfmt --version
 # 出力例: rustfmt 1.9.0-stable (xxx)
 
 cargo clippy --version
-# 出力例: clippy 0.1.92 (xxx)
+# 出力例: clippy 0.1.93 (xxx)
 ```
 
 ---


### PR DESCRIPTION
## Issue

なし

## Summary

- Rust ツールチェインを 1.92.0 → 1.93.0 にアップグレード
- `rust-toolchain.toml`、Dockerfile、CI ワークフロー、README バッジ、開発環境構築手順書を更新

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `backend/rust-toolchain.toml` | `channel = "1.93.0"` |
| `backend/Dockerfile` | `rust:1.93-slim-bookworm` |
| `.github/workflows/ci.yaml` | `toolchain: 1.93.0`（3箇所） |
| `README.md` | バッジを 1.93 に更新 |
| `docs/04_手順書/01_開発参画/01_開発環境構築.md` | バージョン表記・出力例を更新 |

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 参照の網羅性 | OK | `1.92` を grep し、prompts（履歴）以外の全参照を更新済み |
| 2 | ビルド確認 | OK | `cargo check --all-features` が正常完了 |

## Test plan

- CI で `just check-all` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)