### PR TITLE
Add monthly assess workflow for scheduled project health diagnosis

### DIFF
--- a/.github/workflows/monthly-assess.yaml
+++ b/.github/workflows/monthly-assess.yaml
@@ -1,0 +1,70 @@
+# 月次プロジェクト健全性診断 Issue の自動作成
+#
+# 毎月 1 日 9:00 JST に `/assess` 実施を促す Issue を作成する。
+# 手動トリガー（workflow_dispatch）にも対応。
+
+name: Monthly Assess
+
+on:
+  schedule:
+    # 毎月 1 日 0:00 UTC = 9:00 JST
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  create-assess-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate month range
+        id: month
+        run: |
+          # 前月の 1 日〜末日を算出
+          PREV_MONTH_START=$(date -d "$(date +%Y-%m-01) - 1 month" +%Y-%m-%d)
+          PREV_MONTH_END=$(date -d "$(date +%Y-%m-01) - 1 day" +%Y-%m-%d)
+          TODAY=$(date +%Y-%m-%d)
+          {
+            echo "start=${PREV_MONTH_START}"
+            echo "end=${PREV_MONTH_END}"
+            echo "today=${TODAY}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create assess issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh issue create \
+            --title "月次プロジェクト健全性診断 (${{ steps.month.outputs.today }})" \
+            --label "process" \
+            --body "$(cat <<'BODY'
+          ## 概要
+
+          月次プロジェクト健全性診断の実施 Issue。
+
+          対象期間: ${{ steps.month.outputs.start }} 〜 ${{ steps.month.outputs.end }}
+
+          ## チェックリスト
+
+          - [ ] `/assess` を実行（フルモードまたは特定軸）
+          - [ ] レポートを `prompts/reports/` に保存
+          - [ ] 推奨アクションから必要な Issue を作成
+
+          ## 実施方法
+
+          ```
+          /assess
+          ```
+
+          特定軸のみ診断したい場合:
+          ```
+          /assess discovery
+          /assess delivery
+          /assess sustainability
+          ```
+
+          → スキル詳細: `.claude/skills/assess/SKILL.md`
+          BODY
+          )"


### PR DESCRIPTION
## Issue

なし

## 概要

`/assess`（月次プロジェクト健全性診断）のスケジュール実行ワークフローを追加。

既存の `weekly-retro.yaml` と同じパターンで、毎月1日 9:00 JST に `/assess` 実施を促す Issue を自動作成する。

## 変更内容

- `.github/workflows/monthly-assess.yaml` を新規作成
  - 毎月1日 0:00 UTC（9:00 JST）にスケジュール実行
  - `workflow_dispatch` による手動トリガーにも対応
  - 前月の期間を算出して Issue 本文に記載
  - `/assess` の実行手順（フルモード・特定軸）をチェックリストで提示

## 運用サイクルとの関係

```
[毎月1日] /assess → [毎週月曜] /retro → Issue化 → /next → 実装
```

`/retro` の Step 2（トレンド分析）は `/assess` レポートを参照するため、月初に assess が先に実行される設計。

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 既存パターンとの一貫性 | OK | `weekly-retro.yaml` と同じ構造・スタイルで作成 |
| 2 | 外部 Action の使用 | OK | なし（`gh` CLI のみ） |
| 3 | cron 式の正確性 | OK | `0 0 1 * *` = 毎月1日 0:00 UTC |
| 4 | 日付計算の正確性 | OK | 月末日は `date` コマンドで正確に算出 |

## Test plan

- [ ] `workflow_dispatch` で手動実行し、Issue が正しく作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)