### PR TITLE
#414 Fix docker compose env file for worktree environments

### DIFF
--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ setup-labels:
 dev-deps:
     #!/usr/bin/env bash
     PROJECT_NAME=$(basename "$(pwd)")
-    docker compose -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml up -d --wait
+    docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml up -d --wait
     echo "PostgreSQL: localhost:${POSTGRES_PORT}"
     echo "Redis: localhost:${REDIS_PORT}"
     echo "プロジェクト名: $PROJECT_NAME"
@@ -149,7 +149,7 @@ dev-all: dev-deps
 dev-down:
     #!/usr/bin/env bash
     PROJECT_NAME=$(basename "$(pwd)")
-    docker compose -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down
+    docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down
 
 # 開発サーバープロセスを一括終了（mprocs がハングしたとき用）
 dev-kill:
@@ -396,7 +396,7 @@ pre-commit: sqlx-prepare check-all
 clean:
     #!/usr/bin/env bash
     PROJECT_NAME=$(basename "$(pwd)")
-    docker compose -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down -v
+    docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down -v
     cd backend && cargo clean
     cd frontend && rm -rf node_modules elm-stuff dist
 
@@ -439,10 +439,10 @@ worktree-remove name:
     echo "worktree を削除中: {{name}}"
 
     # Docker コンテナを停止・削除
-    containers=$(docker compose -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml ps -q 2>/dev/null || true)
+    containers=$(docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml ps -q 2>/dev/null || true)
     if [[ -n "$containers" ]]; then
         echo "  Docker コンテナを停止中..."
-        docker compose -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down -v
+        docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down -v
     fi
 
     # worktree を削除


### PR DESCRIPTION
## Issue

Closes #414

## 概要

`justfile` の docker compose コマンドに `--env-file .env` を明示的に指定し、worktree 環境でもポートマッピングが正しく設定されるようにする。

## 変更内容

`docker-compose.yaml`（環境変数でポートを参照）を使うすべてのレシピに `--env-file .env` を追加:

- `dev-deps`: コンテナ起動
- `dev-down`: コンテナ停止
- `clean`: クリーンアップ
- `worktree-remove`: worktree 削除時のコンテナ停止

`docker-compose.api-test.yaml` はポートがハードコードされているため変更不要。

## 原因

`docker compose -f infra/docker/docker-compose.yaml` を指定すると、docker compose のプロジェクトディレクトリが `infra/docker/` になり、ルートの `.env` を自動参照しない。`justfile` の `set dotenv-load` はレシピのシェル環境に `.env` を読み込むが、docker compose は独自の変数解決を行うため、明示的な `--env-file` 指定が必要。

## Test plan

最終 Phase 完了後に確認（単一コミットのため、本 PR で確認）:
- [ ] worktree 環境で `just dev-deps` を実行し、ポートマッピングが設定されることを確認
- [ ] `docker ps` でコンテナのポートが表示されることを確認

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 修正箇所の網羅性 | OK | `docker-compose.yaml` を参照する全5箇所に `--env-file .env` を追加 |
| 2 | 非対象の確認 | OK | `docker-compose.api-test.yaml` はハードコードポートのため変更不要 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)