### PR TITLE
Fix worktree setup using wrong ports due to inherited env vars

### DIFF
--- a/justfile
+++ b/justfile
@@ -73,7 +73,7 @@ setup-hooks:
 # データベースをセットアップ（マイグレーション適用）
 setup-db:
     @echo "データベースをセットアップ中..."
-    @cd backend && sqlx migrate run 2>/dev/null || echo "  マイグレーションファイルなし（Phase 1 で作成予定）"
+    @cd backend && sqlx migrate run
     @echo "✓ データベースセットアップ完了"
 
 # worktree 用セットアップ（Docker 起動 → DB マイグレーション → 依存関係インストール）

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -116,7 +116,10 @@ cd "$WORKTREE_PATH"
 if [[ "$NO_SETUP" == false ]]; then
     echo ""
     echo "セットアップを実行中..."
-    just setup-worktree
+    # 親プロセス（メインリポジトリの just）から継承されたポート環境変数をクリアする。
+    # just の dotenv-load は既存の環境変数を上書きしないため、
+    # クリアしないと worktree の .env ではなくメインの .env の値が使われてしまう。
+    env -u POSTGRES_PORT -u REDIS_PORT -u BFF_PORT -u VITE_PORT just setup-worktree
 else
     echo ""
     echo "（--no-setup: セットアップをスキップしました）"


### PR DESCRIPTION
## Issue

なし（ユーザー報告のバグ修正）

## Summary

`just worktree-issue` で worktree を作成する際、メインリポジトリの `just` が `set dotenv-load` で読み込んだポート環境変数（`POSTGRES_PORT` 等）が子プロセスに継承され、worktree の `.env` の値をシャドウイングしていた。

これにより Docker はメインリポジトリのポートにバインドし、`sqlx migrate run` は worktree のポートに接続しようとするため「Connection refused」エラーが発生していた。

### 変更内容

1. **`scripts/worktree-add.sh`**: `env -u` で継承されたポート環境変数をクリアしてから `just setup-worktree` を呼び出すようにした
2. **`justfile` の `setup-db`**: マイグレーションが存在する現在、`2>/dev/null || echo "..."` のサイレント失敗パターンを削除し、エラーを正しく伝播させるようにした

### 根本原因

dotenv の標準仕様として `.env` ファイルの値は既存の環境変数を上書きしない。`just worktree-issue`（メインリポジトリ）→ `just setup-worktree`（worktree）の2段階呼び出しで、親の環境変数がリークしていた。

## Test plan

- [x] `just worktree-issue 410` で worktree を作成し、全ステップが正常完了することを確認済み
  - Docker が正しいポート（15532）で起動
  - マイグレーション 25 件が全て適用
  - `cargo build` 成功
  - `pnpm install` 成功

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 修正の妥当性 | OK | `env -u` で必要な4変数のみクリア、他の環境変数に影響なし |
| 2 | 既存動作への影響 | OK | メインリポジトリでの `just setup` は環境変数の継承がないため影響なし |
| 3 | setup-db のエラー伝播 | OK | マイグレーション失敗時に `just` がエラーで停止し、後続の `cargo build` を防ぐ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)