### PR TITLE
Fix Redis test connection by resolving port from REDIS_PORT env var

### DIFF
--- a/backend/apps/bff/tests/auth_integration_test.rs
+++ b/backend/apps/bff/tests/auth_integration_test.rs
@@ -53,8 +53,16 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 /// テスト用の Redis URL
+///
+/// 優先順位:
+/// 1. `REDIS_URL`（CI で明示的に設定）
+/// 2. `REDIS_PORT` から構築（justfile が root `.env` から渡す）
+/// 3. フォールバック: `redis://localhost:16379`
 fn redis_url() -> String {
-   std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:16379".to_string())
+   std::env::var("REDIS_URL").unwrap_or_else(|_| {
+      let port = std::env::var("REDIS_PORT").unwrap_or_else(|_| "16379".to_string());
+      format!("redis://localhost:{port}")
+   })
 }
 
 /// テスト用のテナント ID

--- a/backend/crates/infra/tests/session_test.rs
+++ b/backend/crates/infra/tests/session_test.rs
@@ -14,8 +14,16 @@ use ringiflow_infra::session::{RedisSessionManager, SessionData, SessionManager}
 use uuid::Uuid;
 
 /// テスト用の Redis URL
+///
+/// 優先順位:
+/// 1. `REDIS_URL`（CI で明示的に設定）
+/// 2. `REDIS_PORT` から構築（justfile が root `.env` から渡す）
+/// 3. フォールバック: `redis://localhost:16379`
 fn redis_url() -> String {
-   std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:16379".to_string())
+   std::env::var("REDIS_URL").unwrap_or_else(|_| {
+      let port = std::env::var("REDIS_PORT").unwrap_or_else(|_| "16379".to_string());
+      format!("redis://localhost:{port}")
+   })
 }
 
 /// テスト用のセッションデータを作成


### PR DESCRIPTION
## Issue

Closes #422

## 概要

Redis 統合テスト（`auth_integration_test`, `session_test`）が worktree 環境で `Connection refused` で失敗する問題を修正。

## 原因

テストコードの `redis_url()` 関数は `REDIS_URL` 環境変数を読み、なければ `redis://localhost:16379` にフォールバックしていた。しかし:

- justfile の `set dotenv-load := true` はルートの `.env` を読む
- ルート `.env` には `REDIS_PORT` はあるが `REDIS_URL` はない
- worktree 環境では `REDIS_PORT` がオフセット（例: `16479`）されるため、フォールバック値 `16379` と不一致

## 修正内容

`redis_url()` にフォールバックチェーンを追加:

1. `REDIS_URL`（CI で明示的に設定）
2. `REDIS_PORT` から構築（justfile がルート `.env` から渡す）
3. ハードコードフォールバック: `redis://localhost:16379`

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 既存パターン整合 | OK | 両テストファイルの `redis_url()` を同一パターンで修正 |
| 2 | CI 互換性 | OK | CI は `REDIS_URL` を明示設定しているため影響なし |
| 3 | `just check-all` pass | OK | ローカルで全テスト通過確認済み |

## Test plan

- `just check-all` が通ることを確認（CI で検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)