### PR TITLE
Fix MCP PostgreSQL server to use dynamic port from .env

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "postgres": {
       "command": "bash",
-      "args": ["scripts/mcp-postgres.sh"],
-      "env": {
-        "DATABASE_URL": "postgresql://ringiflow:ringiflow@localhost:15432/ringiflow_dev"
-      }
+      "args": ["scripts/mcp-postgres.sh"]
     }
   }
 }

--- a/scripts/mcp-postgres.sh
+++ b/scripts/mcp-postgres.sh
@@ -8,6 +8,16 @@
 # 詳細: docs/05_ADR/028_MCPサーバー導入（PostgreSQL）.md
 set -euo pipefail
 
+# プロジェクトルートの .env からポート設定を読み込む（worktree 対応）
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+if [ -f "$PROJECT_ROOT/.env" ]; then
+    # shellcheck source=/dev/null
+    source "$PROJECT_ROOT/.env"
+fi
+
+export DATABASE_URL="${DATABASE_URL:-postgresql://ringiflow:ringiflow@localhost:${POSTGRES_PORT:-15432}/ringiflow_dev}"
+
 PACKAGE="@zeddotdev/postgres-context-server"
 INSTALL_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/ringiflow-mcp-postgres"
 


### PR DESCRIPTION
## Issue

なし

## 概要

MCP PostgreSQL サーバーの `DATABASE_URL` が `.mcp.json` でポート 15432 にハードコードされており、worktree 環境で正しいデータベースに接続できない問題を修正。

## 変更内容

- `.mcp.json`: ハードコードされた `DATABASE_URL` の env 設定を削除
- `scripts/mcp-postgres.sh`: プロジェクトルートの `.env` から `POSTGRES_PORT` を読み込み、`DATABASE_URL` を動的に構築するよう変更

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | worktree 動作 | OK | `.env` の `POSTGRES_PORT` から正しい URL を構築。デフォルト値 15432 で main worktree も動作 |
| 2 | 後方互換性 | OK | `.env` がない場合もデフォルト値でフォールバック |

## Test plan

- main worktree で Claude Code を起動し、MCP PostgreSQL サーバーが正常に接続することを確認
- worktree 環境で異なるポート（例: 15532）の PostgreSQL に正しく接続することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)