### PR TITLE
#474 Add --auto flag prohibition and merge failure handling

### DIFF
--- a/.claude/skills/review-and-merge/SKILL.md
+++ b/.claude/skills/review-and-merge/SKILL.md
@@ -176,3 +176,26 @@ just clean-branches
 ```
 
 マージ完了後、PR の URL を表示して終了する。
+
+**禁止フラグ:** `--auto`、`--admin` は使用しない。
+
+- `--auto`: 全チェック通過時に即座にマージするため、その後にプッシュしたコミットがマージに含まれない
+- `--admin`: branch protection をバイパスするため、品質ゲートが無効になる
+
+#### `gh pr merge` 失敗時の対応
+
+`gh pr merge --squash --delete-branch` が失敗した場合、`--auto` にフォールバックせず以下の手順で対応する:
+
+1. エラーメッセージから原因を特定する
+2. 原因を解消する（下表参照）
+3. 解消後、`gh pr merge --squash --delete-branch` を再試行する
+
+| 原因 | 対応 |
+|------|------|
+| CI チェックが未完了 | `gh pr checks --watch` で待機してから再試行 |
+| レビュー未承認 | Step 2 に戻り、レビュー完了を待つ |
+| 未 resolve のスレッドあり | スレッドを resolve してから再試行 |
+| base branch と差分あり | rebase + push → CI + Review 完了を待ってから再試行 |
+| その他 | 原因をユーザーに報告し、対応を相談する |
+
+改善の経緯: [auto-merge による後続コミット漏れ](../../../prompts/improvements/2026-02/2026-02-11_2234_auto-mergeによる後続コミット漏れ.md)


### PR DESCRIPTION
## Issue

Closes #474

## 変更内容

`/review-and-merge` スキルの Step 5（マージ実行）に以下を追加:

1. **禁止フラグの明記**: `--auto` と `--admin` の使用を禁止し、理由を記載
2. **失敗時の対応手順**: `gh pr merge` が失敗した場合のフォールバック手順を原因別テーブルで定義（原因特定 → 解消 → 再試行）

## 背景

`gh pr merge --squash` が branch protection で失敗した際に `--auto` にフォールバックした結果、後続コミットがマージに含まれない問題が再発した（改善記録参照）。

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 完了基準の充足 | OK | `--auto` 禁止の明記、失敗時フォールバック手順の定義、両方とも記載済み |
| 2 | 文体の整合性 | OK | 既存の Step 5 の形式（テーブル + コードブロック + 改善の経緯リンク）に準拠 |
| 3 | 改善記録リンク | OK | 改善の経緯として改善記録へのリンクを追加済み |

## Test plan

- [ ] SKILL.md の Markdown が正しくレンダリングされることを確認
- [ ] 禁止フラグセクションが Step 5 内の適切な位置にあることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)