### PR TITLE
#511 Eliminate Redocly lint warnings and promote rules to error

### DIFF
--- a/backend/apps/bff/src/bin/generate_openapi.rs
+++ b/backend/apps/bff/src/bin/generate_openapi.rs
@@ -1,6 +1,7 @@
 //! # OpenAPI YAML 生成ツール
 //!
 //! BFF の Rust 型から OpenAPI 仕様を YAML 形式で標準出力に出力する。
+//! 生成後、utoipa が自動登録する未使用コンポーネントスキーマを除去する。
 //!
 //! ## 使い方
 //!
@@ -8,12 +9,43 @@
 //! cargo run --bin generate-openapi -p ringiflow-bff > openapi/openapi.yaml
 //! ```
 
+use std::collections::HashSet;
+
 use ringiflow_bff::openapi::ApiDoc;
 use utoipa::OpenApi;
 
 fn main() {
-   let yaml = ApiDoc::openapi()
-      .to_yaml()
-      .expect("OpenAPI YAML 生成に失敗しました");
+   let mut openapi = ApiDoc::openapi();
+   remove_unused_schemas(&mut openapi);
+   let yaml = openapi.to_yaml().expect("OpenAPI YAML 生成に失敗しました");
    print!("{yaml}");
+}
+
+/// utoipa が自動登録する未使用コンポーネントスキーマを除去する
+///
+/// utoipa の `#[utoipa::path]` マクロは `body = ApiResponse<T>` を処理する際、
+/// ジェネリック型パラメータ `T` の standalone スキーマも自動登録する。
+/// `ApiResponse` は `T` のフィールドを inline 展開するため、standalone スキーマは
+/// どこからも `$ref` されず未使用になる。この関数でそれらを除去する。
+fn remove_unused_schemas(openapi: &mut utoipa::openapi::OpenApi) {
+   // JSON にシリアライズして全 $ref ターゲットを収集する
+   let json = serde_json::to_string(openapi).expect("JSON シリアライズに失敗しました");
+
+   // $ref パターンから参照先スキーマ名を抽出する
+   // JSON 形式: "$ref":"#/components/schemas/SchemaName"
+   let prefix = "#/components/schemas/";
+   let used_schemas: HashSet<&str> = json
+      .match_indices(prefix)
+      .filter_map(|(start, _)| {
+         let rest = &json[start + prefix.len()..];
+         // スキーマ名の終端は `"` （JSON 文字列の閉じ引用符）
+         rest.find('"').map(|end| &rest[..end])
+      })
+      .collect();
+
+   if let Some(components) = &mut openapi.components {
+      components
+         .schemas
+         .retain(|name, _| used_schemas.contains(name.as_str()));
+   }
 }

--- a/backend/apps/bff/src/handler/audit_log.rs
+++ b/backend/apps/bff/src/handler/audit_log.rs
@@ -24,7 +24,7 @@ use ringiflow_infra::{
    SessionManager,
    repository::audit_log_repository::{AuditLogFilter, AuditLogRepository},
 };
-use ringiflow_shared::PaginatedResponse;
+use ringiflow_shared::{ErrorResponse, PaginatedResponse};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
@@ -83,7 +83,8 @@ pub struct AuditLogItemData {
    security(("session_auth" = [])),
    params(ListAuditLogsQuery),
    responses(
-      (status = 200, description = "監査ログ一覧", body = PaginatedResponse<AuditLogItemData>)
+      (status = 200, description = "監査ログ一覧", body = PaginatedResponse<AuditLogItemData>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn list_audit_logs(

--- a/backend/apps/bff/src/handler/dashboard.rs
+++ b/backend/apps/bff/src/handler/dashboard.rs
@@ -15,7 +15,7 @@ use axum::{
    response::IntoResponse,
 };
 use axum_extra::extract::CookieJar;
-use ringiflow_shared::ApiResponse;
+use ringiflow_shared::{ApiResponse, ErrorResponse};
 use serde::Serialize;
 use utoipa::ToSchema;
 
@@ -56,7 +56,8 @@ impl From<DashboardStatsDto> for DashboardStatsData {
    tag = "dashboard",
    security(("session_auth" = [])),
    responses(
-      (status = 200, description = "ダッシュボード統計", body = ApiResponse<DashboardStatsData>)
+      (status = 200, description = "ダッシュボード統計", body = ApiResponse<DashboardStatsData>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn get_dashboard_stats(

--- a/backend/apps/bff/src/handler/role.rs
+++ b/backend/apps/bff/src/handler/role.rs
@@ -105,7 +105,8 @@ pub struct RoleDetailData {
    tag = "roles",
    security(("session_auth" = [])),
    responses(
-      (status = 200, description = "ロール一覧", body = ApiResponse<Vec<RoleItemData>>)
+      (status = 200, description = "ロール一覧", body = ApiResponse<Vec<RoleItemData>>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn list_roles(

--- a/backend/apps/bff/src/handler/task.rs
+++ b/backend/apps/bff/src/handler/task.rs
@@ -16,7 +16,7 @@ use axum::{
    response::IntoResponse,
 };
 use axum_extra::extract::CookieJar;
-use ringiflow_shared::ApiResponse;
+use ringiflow_shared::{ApiResponse, ErrorResponse};
 use serde::Serialize;
 use utoipa::ToSchema;
 
@@ -110,7 +110,8 @@ impl From<crate::client::TaskDetailDto> for TaskDetailData {
    tag = "tasks",
    security(("session_auth" = [])),
    responses(
-      (status = 200, description = "タスク一覧", body = ApiResponse<Vec<TaskItemData>>)
+      (status = 200, description = "タスク一覧", body = ApiResponse<Vec<TaskItemData>>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn list_my_tasks(

--- a/backend/apps/bff/src/handler/user.rs
+++ b/backend/apps/bff/src/handler/user.rs
@@ -173,7 +173,8 @@ fn generate_initial_password() -> String {
    security(("session_auth" = [])),
    params(ListUsersQuery),
    responses(
-      (status = 200, description = "ユーザー一覧", body = ApiResponse<Vec<UserItemData>>)
+      (status = 200, description = "ユーザー一覧", body = ApiResponse<Vec<UserItemData>>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn list_users(

--- a/backend/apps/bff/src/handler/workflow/query.rs
+++ b/backend/apps/bff/src/handler/workflow/query.rs
@@ -46,7 +46,8 @@ use crate::{
    tag = "workflows",
    security(("session_auth" = [])),
    responses(
-      (status = 200, description = "ワークフロー定義一覧", body = ApiResponse<Vec<WorkflowDefinitionData>>)
+      (status = 200, description = "ワークフロー定義一覧", body = ApiResponse<Vec<WorkflowDefinitionData>>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn list_workflow_definitions(
@@ -164,7 +165,8 @@ pub async fn get_workflow_definition(
    tag = "workflows",
    security(("session_auth" = [])),
    responses(
-      (status = 200, description = "自分のワークフロー一覧", body = ApiResponse<Vec<WorkflowData>>)
+      (status = 200, description = "自分のワークフロー一覧", body = ApiResponse<Vec<WorkflowData>>),
+      (status = 401, description = "認証エラー", body = ErrorResponse)
    )
 )]
 pub async fn list_my_workflows(

--- a/backend/apps/bff/src/openapi.rs
+++ b/backend/apps/bff/src/openapi.rs
@@ -9,7 +9,7 @@ use utoipa::{
    openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
 };
 
-use crate::handler::{audit_log, auth, dashboard, health, role, task, user, workflow};
+use crate::handler::{audit_log, auth, dashboard, role, task, user, workflow};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -19,8 +19,6 @@ use crate::handler::{audit_log, auth, dashboard, health, role, task, user, workf
       description = "ワークフロー管理システム RingiFlow の BFF API"
    ),
    paths(
-      // health
-      health::health_check,
       // auth
       auth::login,
       auth::logout,
@@ -60,70 +58,9 @@ use crate::handler::{audit_log, auth, dashboard, health, role, task, user, workf
       dashboard::get_dashboard_stats,
    ),
    components(schemas(
-      // shared
-      ringiflow_shared::ApiResponse<auth::LoginResponseData>,
-      ringiflow_shared::ApiResponse<auth::MeResponseData>,
-      ringiflow_shared::ApiResponse<auth::CsrfResponseData>,
-      ringiflow_shared::ApiResponse<Vec<workflow::WorkflowDefinitionData>>,
-      ringiflow_shared::ApiResponse<workflow::WorkflowDefinitionData>,
-      ringiflow_shared::ApiResponse<Vec<workflow::WorkflowData>>,
-      ringiflow_shared::ApiResponse<workflow::WorkflowData>,
-      ringiflow_shared::ApiResponse<Vec<task::TaskItemData>>,
-      ringiflow_shared::ApiResponse<task::TaskDetailData>,
-      ringiflow_shared::ApiResponse<Vec<user::UserItemData>>,
-      ringiflow_shared::ApiResponse<user::CreateUserResponseData>,
-      ringiflow_shared::ApiResponse<user::UserDetailData>,
-      ringiflow_shared::ApiResponse<user::UserResponseData>,
-      ringiflow_shared::ApiResponse<dashboard::DashboardStatsData>,
       ringiflow_shared::ErrorResponse,
-      // health
-      health::HealthResponse,
-      // auth
-      auth::LoginRequest,
-      auth::LoginResponseData,
-      auth::LoginUserResponse,
-      auth::MeResponseData,
-      auth::CsrfResponseData,
-      // workflow
-      workflow::CreateWorkflowRequest,
-      workflow::SubmitWorkflowRequest,
-      workflow::ApproveRejectRequest,
-      workflow::ResubmitWorkflowRequest,
-      workflow::UserRefData,
-      workflow::WorkflowStepData,
-      workflow::WorkflowData,
-      workflow::WorkflowDefinitionData,
-      workflow::PostCommentRequest,
-      workflow::WorkflowCommentData,
-      ringiflow_shared::ApiResponse<workflow::WorkflowCommentData>,
-      ringiflow_shared::ApiResponse<Vec<workflow::WorkflowCommentData>>,
-      // task
-      task::TaskWorkflowSummaryData,
-      task::TaskItemData,
-      task::TaskDetailData,
-      // user
-      user::CreateUserRequest,
-      user::UpdateUserRequest,
-      user::UpdateUserStatusRequest,
-      user::UserItemData,
-      user::CreateUserResponseData,
-      user::UserDetailData,
-      user::UserResponseData,
-      // audit_log
-      audit_log::AuditLogItemData,
-      ringiflow_shared::PaginatedResponse<audit_log::AuditLogItemData>,
-      // role
-      role::CreateRoleRequest,
-      role::UpdateRoleRequest,
-      role::RoleItemData,
-      role::RoleDetailData,
-      ringiflow_shared::ApiResponse<Vec<role::RoleItemData>>,
-      ringiflow_shared::ApiResponse<role::RoleDetailData>,
-      // dashboard
-      dashboard::DashboardStatsData,
    )),
    tags(
-      (name = "health", description = "ヘルスチェック"),
       (name = "auth", description = "認証"),
       (name = "workflows", description = "ワークフロー管理"),
       (name = "tasks", description = "タスク管理"),

--- a/backend/apps/bff/tests/openapi_spec.rs
+++ b/backend/apps/bff/tests/openapi_spec.rs
@@ -17,11 +17,11 @@ fn test_全パスが含まれている() {
    let doc = ApiDoc::openapi();
    let paths: Vec<&str> = doc.paths.paths.keys().map(|k| k.as_str()).collect();
 
-   // 24 パス（30 ハンドラ、同一パスに複数メソッドがあるため 24 パス）
-   assert_eq!(paths.len(), 24, "パス数が 24 であること: {paths:?}");
+   // 23 パス（29 ハンドラ、同一パスに複数メソッドがあるため 23 パス）
+   // /health はインフラ用のため OpenAPI 仕様には含めない
+   assert_eq!(paths.len(), 23, "パス数が 23 であること: {paths:?}");
 
    // 全パスの存在確認
-   assert!(paths.contains(&"/health"));
    assert!(paths.contains(&"/api/v1/auth/login"));
    assert!(paths.contains(&"/api/v1/auth/logout"));
    assert!(paths.contains(&"/api/v1/auth/me"));
@@ -76,7 +76,6 @@ fn test_全タグが含まれている() {
       .map(|t| t.name.as_str())
       .collect();
 
-   assert!(tags.contains(&"health"));
    assert!(tags.contains(&"auth"));
    assert!(tags.contains(&"workflows"));
    assert!(tags.contains(&"tasks"));

--- a/backend/apps/bff/tests/snapshots/openapi_spec__openapi_spec.snap
+++ b/backend/apps/bff/tests/snapshots/openapi_spec__openapi_spec.snap
@@ -1,5 +1,6 @@
 ---
 source: apps/bff/tests/openapi_spec.rs
+assertion_line: 103
 expression: json
 ---
 {
@@ -96,6 +97,16 @@ expression: json
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PaginatedResponse_AuditLogItemData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -282,6 +293,16 @@ expression: json
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -306,6 +327,16 @@ expression: json
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiResponse_Vec_RoleItemData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -547,6 +578,16 @@ expression: json
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -581,6 +622,16 @@ expression: json
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiResponse_Vec_UserItemData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -851,6 +902,16 @@ expression: json
                 }
               }
             }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -924,6 +985,16 @@ expression: json
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ApiResponse_Vec_WorkflowData"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "認証エラー",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1678,28 +1749,6 @@ expression: json
             "session_auth": []
           }
         ]
-      }
-    },
-    "/health": {
-      "get": {
-        "tags": [
-          "health"
-        ],
-        "summary": "ヘルスチェックエンドポイント",
-        "description": "サーバーが正常に稼働していることを確認するためのエンドポイント。",
-        "operationId": "health_check",
-        "responses": {
-          "200": {
-            "description": "サーバー稼働中",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HealthResponse"
-                }
-              }
-            }
-          }
-        }
       }
     }
   },
@@ -2783,24 +2832,6 @@ expression: json
           }
         }
       },
-      "HealthResponse": {
-        "type": "object",
-        "description": "ヘルスチェックレスポンス",
-        "required": [
-          "status",
-          "version"
-        ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "稼働状態（`\"healthy\"` または `\"unhealthy\"`）"
-          },
-          "version": {
-            "type": "string",
-            "description": "アプリケーションバージョン（Cargo.toml から取得）"
-          }
-        }
-      },
       "LoginRequest": {
         "type": "object",
         "description": "ログインリクエスト",
@@ -3699,10 +3730,6 @@ expression: json
     }
   },
   "tags": [
-    {
-      "name": "health",
-      "description": "ヘルスチェック"
-    },
     {
       "name": "auth",
       "description": "認証"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -68,6 +68,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResponse_AuditLogItemData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
   /api/v1/auth/csrf:
@@ -205,6 +211,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_DashboardStatsData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
   /api/v1/roles:
@@ -223,6 +235,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Vec_RoleItemData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
     post:
@@ -368,6 +386,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Vec_TaskItemData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
   /api/v1/users:
@@ -392,6 +416,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Vec_UserItemData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
     post:
@@ -572,6 +602,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Vec_WorkflowDefinitionData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
   /api/v1/workflow-definitions/{id}:
@@ -632,6 +668,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse_Vec_WorkflowData'
+        '401':
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
     post:
@@ -1153,20 +1195,6 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
       security:
       - session_auth: []
-  /health:
-    get:
-      tags:
-      - health
-      summary: ヘルスチェックエンドポイント
-      description: サーバーが正常に稼働していることを確認するためのエンドポイント。
-      operationId: health_check
-      responses:
-        '200':
-          description: サーバー稼働中
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthResponse'
 components:
   schemas:
     ApiResponse_CreateUserResponseData:
@@ -2086,40 +2114,6 @@ components:
           - string
           - 'null'
           description: コメント（任意）
-    AuditLogItemData:
-      type: object
-      description: 監査ログ一覧の要素データ
-      required:
-      - id
-      - actor_id
-      - actor_name
-      - action
-      - result
-      - resource_type
-      - resource_id
-      - created_at
-      properties:
-        id:
-          type: string
-        actor_id:
-          type: string
-        actor_name:
-          type: string
-        action:
-          type: string
-        result:
-          type: string
-        resource_type:
-          type: string
-        resource_id:
-          type: string
-        detail: {}
-        source_ip:
-          type:
-          - string
-          - 'null'
-        created_at:
-          type: string
     CreateRoleRequest:
       type: object
       description: ロール作成リクエスト
@@ -2151,33 +2145,6 @@ components:
           type: string
         role_name:
           type: string
-    CreateUserResponseData:
-      type: object
-      description: ユーザー作成レスポンス（初期パスワード付き）
-      required:
-      - id
-      - display_id
-      - display_number
-      - name
-      - email
-      - role
-      - initial_password
-      properties:
-        id:
-          type: string
-        display_id:
-          type: string
-        display_number:
-          type: integer
-          format: int64
-        name:
-          type: string
-        email:
-          type: string
-        role:
-          type: string
-        initial_password:
-          type: string
     CreateWorkflowRequest:
       type: object
       description: ワークフロー作成リクエスト（BFF 公開 API）
@@ -2195,44 +2162,6 @@ components:
           description: ワークフロータイトル
         form_data:
           description: フォームデータ
-    CsrfResponseData:
-      type: object
-      description: CSRF トークンデータ
-      required:
-      - token
-      properties:
-        token:
-          type: string
-    DashboardStatsData:
-      type: object
-      description: ダッシュボード統計データ
-      required:
-      - pending_tasks
-      - my_workflows_in_progress
-      - completed_today
-      properties:
-        pending_tasks:
-          type: integer
-          format: int64
-        my_workflows_in_progress:
-          type: integer
-          format: int64
-        completed_today:
-          type: integer
-          format: int64
-    HealthResponse:
-      type: object
-      description: ヘルスチェックレスポンス
-      required:
-      - status
-      - version
-      properties:
-        status:
-          type: string
-          description: 稼働状態（`"healthy"` または `"unhealthy"`）
-        version:
-          type: string
-          description: アプリケーションバージョン（Cargo.toml から取得）
     LoginRequest:
       type: object
       description: ログインリクエスト
@@ -2244,14 +2173,6 @@ components:
           type: string
         password:
           type: string
-    LoginResponseData:
-      type: object
-      description: ログインレスポンスデータ
-      required:
-      - user
-      properties:
-        user:
-          $ref: '#/components/schemas/LoginUserResponse'
     LoginUserResponse:
       type: object
       description: ログインユーザー情報
@@ -2273,38 +2194,6 @@ components:
           type: string
           format: uuid
         roles:
-          type: array
-          items:
-            type: string
-    MeResponseData:
-      type: object
-      description: 現在のユーザー情報データ
-      required:
-      - id
-      - email
-      - name
-      - tenant_id
-      - tenant_name
-      - roles
-      - permissions
-      properties:
-        id:
-          type: string
-          format: uuid
-        email:
-          type: string
-        name:
-          type: string
-        tenant_id:
-          type: string
-          format: uuid
-        tenant_name:
-          type: string
-        roles:
-          type: array
-          items:
-            type: string
-        permissions:
           type: array
           items:
             type: string
@@ -2420,62 +2309,6 @@ components:
           type: integer
           format: int32
           description: 楽観的ロック用バージョン
-    RoleDetailData:
-      type: object
-      description: ロール詳細データ
-      required:
-      - id
-      - name
-      - permissions
-      - is_system
-      - created_at
-      - updated_at
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        description:
-          type:
-          - string
-          - 'null'
-        permissions:
-          type: array
-          items:
-            type: string
-        is_system:
-          type: boolean
-        created_at:
-          type: string
-        updated_at:
-          type: string
-    RoleItemData:
-      type: object
-      description: ロール一覧の要素データ
-      required:
-      - id
-      - name
-      - permissions
-      - is_system
-      - user_count
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        description:
-          type:
-          - string
-          - 'null'
-        permissions:
-          type: array
-          items:
-            type: string
-        is_system:
-          type: boolean
-        user_count:
-          type: integer
-          format: int64
     StepApproverRequest:
       type: object
       description: ステップ承認者リクエスト（BFF 公開 API）
@@ -2501,57 +2334,6 @@ components:
           items:
             $ref: '#/components/schemas/StepApproverRequest'
           description: 各承認ステップの承認者リスト
-    TaskDetailData:
-      type: object
-      description: タスク詳細データ
-      required:
-      - step
-      - workflow
-      properties:
-        step:
-          $ref: '#/components/schemas/WorkflowStepData'
-        workflow:
-          $ref: '#/components/schemas/WorkflowData'
-    TaskItemData:
-      type: object
-      description: タスク一覧の要素データ
-      required:
-      - id
-      - display_number
-      - step_name
-      - status
-      - version
-      - created_at
-      - workflow
-      properties:
-        id:
-          type: string
-        display_number:
-          type: integer
-          format: int64
-        step_name:
-          type: string
-        status:
-          type: string
-        version:
-          type: integer
-          format: int32
-        assigned_to:
-          oneOf:
-          - type: 'null'
-          - $ref: '#/components/schemas/UserRefData'
-        due_date:
-          type:
-          - string
-          - 'null'
-        started_at:
-          type:
-          - string
-          - 'null'
-        created_at:
-          type: string
-        workflow:
-          $ref: '#/components/schemas/TaskWorkflowSummaryData'
     TaskWorkflowSummaryData:
       type: object
       description: ワークフロー概要データ（タスク一覧用）
@@ -2618,72 +2400,6 @@ components:
       properties:
         status:
           type: string
-    UserDetailData:
-      type: object
-      description: ユーザー詳細レスポンス
-      required:
-      - id
-      - display_id
-      - display_number
-      - name
-      - email
-      - status
-      - roles
-      - permissions
-      - tenant_name
-      properties:
-        id:
-          type: string
-        display_id:
-          type: string
-        display_number:
-          type: integer
-          format: int64
-        name:
-          type: string
-        email:
-          type: string
-        status:
-          type: string
-        roles:
-          type: array
-          items:
-            type: string
-        permissions:
-          type: array
-          items:
-            type: string
-        tenant_name:
-          type: string
-    UserItemData:
-      type: object
-      description: ユーザー一覧の要素データ
-      required:
-      - id
-      - display_id
-      - display_number
-      - name
-      - email
-      - status
-      - roles
-      properties:
-        id:
-          type: string
-        display_id:
-          type: string
-        display_number:
-          type: integer
-          format: int64
-        name:
-          type: string
-        email:
-          type: string
-        status:
-          type: string
-        roles:
-          type: array
-          items:
-            type: string
     UserRefData:
       type: object
       description: ユーザー参照データ（フロントエンドへの Serialize 用）
@@ -2694,40 +2410,6 @@ components:
         id:
           type: string
         name:
-          type: string
-    UserResponseData:
-      type: object
-      description: ユーザー簡易レスポンス（更新・ステータス変更用）
-      required:
-      - id
-      - name
-      - email
-      - status
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        email:
-          type: string
-        status:
-          type: string
-    WorkflowCommentData:
-      type: object
-      description: ワークフローコメントデータ
-      required:
-      - id
-      - posted_by
-      - body
-      - created_at
-      properties:
-        id:
-          type: string
-        posted_by:
-          $ref: '#/components/schemas/UserRefData'
-        body:
-          type: string
-        created_at:
           type: string
     WorkflowData:
       type: object
@@ -2781,39 +2463,6 @@ components:
           type:
           - string
           - 'null'
-        created_at:
-          type: string
-        updated_at:
-          type: string
-    WorkflowDefinitionData:
-      type: object
-      description: ワークフロー定義データ
-      required:
-      - id
-      - name
-      - version
-      - definition
-      - status
-      - created_by
-      - created_at
-      - updated_at
-      properties:
-        id:
-          type: string
-        name:
-          type: string
-        description:
-          type:
-          - string
-          - 'null'
-        version:
-          type: integer
-          format: int32
-        definition: {}
-        status:
-          type: string
-        created_by:
-          type: string
         created_at:
           type: string
         updated_at:
@@ -2885,8 +2534,6 @@ components:
       in: cookie
       name: session_id
 tags:
-- name: health
-  description: ヘルスチェック
 - name: auth
   description: 認証
 - name: workflows

--- a/openapi/redocly.yaml
+++ b/openapi/redocly.yaml
@@ -10,8 +10,8 @@ rules:
   # 開発環境用に localhost や example.com を許容
   no-server-example.com: off
 
-  # ヘルスチェック API には 4XX レスポンス不要
-  operation-4xx-response: warn
+  # すべてのエンドポイントに 4XX レスポンスを要求
+  operation-4xx-response: error
 
-  # 将来使用予定のコンポーネントを許容
-  no-unused-components: warn
+  # 未使用コンポーネントを禁止
+  no-unused-components: error

--- a/prompts/plans/fluffy-napping-willow.md
+++ b/prompts/plans/fluffy-napping-willow.md
@@ -1,0 +1,192 @@
+# 計画: Redocly 警告をゼロにする (#511)
+
+## Context
+
+`just check` 実行時に Redocly lint の警告が 23 件出力されている（`operation-4xx-response`: 8件、`no-unused-components`: 15件）。警告をゼロにし、ルールを `error` に昇格させて再発を防止する。
+
+## スコープ
+
+対象:
+- `no-unused-components` 15件の解消
+- `operation-4xx-response` 8件の解消（うち `/health` は設計判断あり）
+- `redocly.yaml` のルールレベル変更（`warn` → `error`）
+
+対象外:
+- jscpd コードクローン（別 Story）
+- ファイルサイズ超過（別 Story）
+- SQLx キャッシュ（既に解消済み）
+
+## 設計判断
+
+### no-unused-components の解消方針
+
+`openapi.rs` の `components(schemas())` に、standalone 型と `ApiResponse<T>` ラッパーの両方が登録されている。`ApiResponse<T>` 経由で inline 展開されるため standalone 型は不要。
+
+削除対象（15件）:
+- `auth::LoginResponseData`, `auth::MeResponseData`, `auth::CsrfResponseData`
+- `workflow::WorkflowDefinitionData`, `workflow::WorkflowData`, `workflow::WorkflowCommentData`
+- `task::TaskItemData`, `task::TaskDetailData`
+- `user::UserItemData`, `user::CreateUserResponseData`, `user::UserDetailData`, `user::UserResponseData`
+- `audit_log::AuditLogItemData`
+- `role::RoleItemData`, `role::RoleDetailData`
+- `dashboard::DashboardStatsData`
+
+注意: `ApiResponse<T>` や `PaginatedResponse<T>` のラッパー、リクエスト型、HealthResponse、ErrorResponse は削除しない（直接参照されるため）。
+
+### operation-4xx-response の解消方針
+
+認証保護された 7 エンドポイント（`security(("session_auth" = []))` あり）:
+- 401 Unauthorized を追加（セッション無効時のレスポンス）
+- `body = ErrorResponse` で統一（既存パターンに準拠）
+
+`/health` エンドポイント:
+- 認証なし、パスパラメータなし、リクエストボディなし → 4xx レスポンスが意味的に存在しない
+- OpenAPI 仕様から `/health` を除外する。ヘルスチェックはインフラ・モニタリング用であり、ビジネス API ではない
+- `openapi.rs` の `paths()` から `health::health_check` を削除し、`tags()` から `health` も削除
+
+代替案:
+1. 意味のない 4xx を追加 → セマンティクスに反する。不採用
+2. redocly の lint-ignore で抑制 → 例外を増やすより根本対処。不採用
+3. `/health` を OpenAPI から除外（採用）→ ヘルスチェックは API 仕様書の対象外が一般的
+
+### redocly.yaml のルール変更
+
+コメントも実態に合わせて更新:
+- `operation-4xx-response: warn` → `error`
+- `no-unused-components: warn` → `error`
+
+## Phase 1: no-unused-components の解消
+
+### 確認事項
+- なし（既知のパターンのみ）
+
+### テストリスト
+
+ユニットテスト（該当なし）
+ハンドラテスト（該当なし）
+API テスト（該当なし）
+E2E テスト（該当なし）
+
+検証: `just openapi-generate` 後に `pnpm exec redocly lint` で `no-unused-components` が 0 件であること
+
+### 変更内容
+
+`backend/apps/bff/src/openapi.rs`:
+- `components(schemas())` から未使用 standalone スキーマ 15 件を削除
+- `paths()` から `health::health_check` を削除
+- `tags()` から health タグを削除
+- `use crate::handler::{...}` から `health` を削除
+
+削除する行:
+```rust
+// 削除: standalone 型（ApiResponse<T> 経由で参照済み）
+auth::LoginResponseData,        // L83
+auth::MeResponseData,           // L85
+auth::CsrfResponseData,         // L86
+workflow::WorkflowData,          // L94
+workflow::WorkflowDefinitionData, // L95
+workflow::WorkflowCommentData,   // L97
+task::TaskItemData,              // L102
+task::TaskDetailData,            // L103
+user::UserItemData,              // L108
+user::CreateUserResponseData,    // L109
+user::UserDetailData,            // L110
+user::UserResponseData,          // L111
+audit_log::AuditLogItemData,     // L113
+role::RoleItemData,              // L118
+role::RoleDetailData,            // L119
+dashboard::DashboardStatsData,   // L123
+```
+
+残す型（直接参照される）:
+- `HealthResponse` → `/health` を除外するので削除対象に変更
+- `ErrorResponse` → responses で直接参照
+- リクエスト型（`LoginRequest`, `CreateWorkflowRequest` 等）→ request_body で直接参照
+- `LoginUserResponse`, `UserRefData`, `WorkflowStepData`, `TaskWorkflowSummaryData` 等 → responses 内で参照
+- `ApiResponse<T>` / `PaginatedResponse<T>` → responses の body で直接参照
+
+## Phase 2: operation-4xx-response の解消
+
+### 確認事項
+- [x] パターン: 既存の 401 レスポンス定義 → `handler/auth.rs` L277,328,389: `(status = 401, description = "未認証", body = ErrorResponse)`
+
+### テストリスト
+
+ユニットテスト（該当なし）
+ハンドラテスト（該当なし）
+API テスト（該当なし）
+E2E テスト（該当なし）
+
+検証: `just openapi-generate` 後に `pnpm exec redocly lint` で `operation-4xx-response` が 0 件であること
+
+### 変更内容
+
+7 つの GET ハンドラに 401 レスポンスを追加:
+
+| ファイル | 関数 | エンドポイント |
+|---------|------|---------------|
+| `handler/workflow/query.rs` | `list_workflow_definitions` | GET /api/v1/workflow-definitions |
+| `handler/workflow/query.rs` | `list_my_workflows` | GET /api/v1/workflows |
+| `handler/task.rs` | `list_my_tasks` | GET /api/v1/tasks/my |
+| `handler/user.rs` | `list_users` | GET /api/v1/users |
+| `handler/role.rs` | `list_roles` | GET /api/v1/roles |
+| `handler/audit_log.rs` | `list_audit_logs` | GET /api/v1/audit-logs |
+| `handler/dashboard.rs` | `get_dashboard_stats` | GET /api/v1/dashboard/stats |
+
+追加パターン:
+```rust
+responses(
+   (status = 200, description = "...", body = ...),
+   (status = 401, description = "認証エラー", body = ErrorResponse)
+)
+```
+
+## Phase 3: redocly.yaml の更新
+
+### 確認事項
+- なし（既知のパターンのみ）
+
+### テストリスト
+
+ユニットテスト（該当なし）
+ハンドラテスト（該当なし）
+API テスト（該当なし）
+E2E テスト（該当なし）
+
+検証: `pnpm exec redocly lint` が警告・エラーゼロで通過
+
+### 変更内容
+
+`openapi/redocly.yaml`:
+```yaml
+rules:
+  no-server-example.com: off
+  operation-4xx-response: error
+  no-unused-components: error
+```
+
+コメントを更新（`warn` 時の理由コメントを削除し、必要に応じて更新）。
+
+## 検証
+
+1. `just openapi-generate` で OpenAPI 仕様を再生成
+2. `pnpm exec redocly lint --config openapi/redocly.yaml` で警告・エラーゼロ
+3. `just check` が通過
+
+## ブラッシュアップループの記録
+
+| ループ | 検出したギャップ | 観点 | 対応 |
+|-------|----------------|------|------|
+| 1回目 | `/health` を OpenAPI から除外する場合、`HealthResponse` も削除対象 | 不完全なパス | Phase 1 に `HealthResponse` 削除と `health` import/tag 削除を追加 |
+| 2回目 | Issue の未使用コンポーネントが 14 件→実際は 15 件（WorkflowCommentData 追加） | 既存手段の見落とし | 削除対象リストを実際の 15 件に更新 |
+
+## 収束確認（設計・計画）
+
+| # | 観点 | 判定 | 確認内容 |
+|---|------|------|---------|
+| 1 | 網羅性 | OK | Redocly 出力の 23 警告すべてに対応策あり（15 unused + 7 GET 4xx + 1 health 除外） |
+| 2 | 曖昧さ排除 | OK | 各ファイル・関数を具体的に列挙、「必要に応じて」等の曖昧表現なし |
+| 3 | 設計判断の完結性 | OK | `/health` 除外の判断理由と代替案を記載 |
+| 4 | スコープ境界 | OK | 対象（Redocly 警告）と対象外（jscpd, ファイルサイズ, SQLx）を明記 |
+| 5 | 技術的前提 | OK | utoipa の inline 展開挙動を既存コードで確認済み |
+| 6 | 既存ドキュメント整合 | OK | OpenAPI 仕様が Single Source of Truth（Issue 駆動開発 4.2）に準拠 |


### PR DESCRIPTION
## Issue

Closes #511

## 概要

`just check` 実行時に出力されていた Redocly lint の警告 23 件をすべて解消し、ルールを `error` に昇格させて再発を防止する。

### 変更内容

- **no-unused-components（15件）**: `openapi.rs` の `components(schemas(...))` を `ErrorResponse` のみに簡素化。ハンドラマクロがスキーマを自動生成するため不要。utoipa が自動登録する未使用スキーマは `generate_openapi.rs` の後処理で除去
- **operation-4xx-response（8件）**: 認証保護された 7 つの GET エンドポイントに 401 レスポンスを追加。`/health` は OpenAPI 仕様から除外（インフラ用エンドポイントのため）
- **redocly.yaml**: 両ルールを `warn` → `error` に昇格

### 設計判断

- `/health` を OpenAPI から除外: ヘルスチェックはインフラ・モニタリング用であり、ビジネス API ではない。4xx レスポンスが意味的に存在しないため、lint-ignore で抑制するより根本対処を選択
- 未使用スキーマの後処理除去: utoipa の `#[utoipa::path]` マクロが `ApiResponse<T>` の型パラメータ `T` を inline 展開しつつ standalone スキーマも自動登録する仕様。`#[schema(inline)]` では制御不可のため、生成後に `$ref` ターゲットを収集し未参照スキーマを除去する後処理を実装

## Test plan

- [x] `just check` 通過
- [x] `pnpm exec redocly lint` が警告・エラーゼロ
- [x] OpenAPI スナップショットテスト更新済み

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 品質チェックリスト | OK | 全項目確認済み |
| 2 | `just check` pass | OK | ローカルで確認済み |

🤖 Generated with [Claude Code](https://claude.com/claude-code)