### PR TITLE
#516 Add main branch sync step to issue-driven development flow

### DIFF
--- a/docs/04_手順書/04_開発フロー/01_Issue駆動開発.md
+++ b/docs/04_手順書/04_開発フロー/01_Issue駆動開発.md
@@ -105,6 +105,13 @@ E2E 基準がないと、各レイヤーが個別に正しくてもレイヤー�
 
 ### 2. ブランチを作成
 
+ブランチ作成前に、ローカルの main を最新化する:
+
+```bash
+git checkout main
+git pull origin main
+```
+
 ```bash
 # Issue 番号に基づいてブランチを作成
 git checkout -b feature/34-user-auth
@@ -113,6 +120,8 @@ git checkout -b feature/34-user-auth
 命名規則:
 - `feature/{issue番号}-{機能名}` — 新機能
 - `fix/{issue番号}-{バグ名}` — バグ修正
+
+改善の経緯: [新規作業開始時の main 同期漏れ](../../../prompts/improvements/2026-02/2026-02-14_2120_新規作業開始時のmain同期漏れ.md)
 
 ### 3. Draft PR を作成
 
@@ -832,6 +841,7 @@ gh api repos/ka2kama/ringiflow/milestones
 
 | 日付 | 変更内容 |
 |------|---------|
+| 2026-02-14 | Step 2 にブランチ作成前の main 最新化ステップを追加（#516） |
 | 2026-02-11 | 6.2 にコンテキスト依存の必須ドキュメント確認項目を追加 |
 | 2026-02-10 | Step 9 に改善記録の検証ステップを追加（#375） |
 | 2026-02-09 | 6.4 に base branch 同期確認ステップを追加（#356） |


### PR DESCRIPTION
## Summary

Issue 駆動開発の手順書（Step 2: ブランチを作成）に、ブランチ作成前の main 最新化ステップを追加した。

## Related

Closes #516

## Changes

- `git checkout main && git pull origin main` の手順を Step 2 に追加
- 改善記録へのリンクを追記
- 変更履歴を更新

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 参照の網羅性 | OK | 改善記録のパスを実ファイルと突合、一致 |
| 2 | 用語の統一 | OK | 既存の「base branch との同期確認」（6.4）と整合する表現 |
| 3 | 意図の明確さ | OK | 何をするか（main 最新化）と改善の経緯が明示されている |
| 4 | 既存フローとの整合 | OK | 6.4 の「Ready 前の同期確認」と対称的に「作業開始前の同期」を追加。重複なし |

## Test plan

- [x] 手順書の変更箇所が既存フローと矛盾しないことを確認
- [x] 改善記録へのリンクが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)