### PR TITLE
#137 Evaluate Elm OpenAPI client generators and decide not to adopt

### DIFF
--- a/docs/05_ADR/047_Elm-OpenAPIクライアント自動生成の見送り.md
+++ b/docs/05_ADR/047_Elm-OpenAPIクライアント自動生成の見送り.md
@@ -180,8 +180,12 @@ Cookie セッションから Bearer Token（JWT など）に移行する。
 
 ### 整合性担保の仕組み
 
-```
-Rust (BFF) → [utoipa] → OpenAPI 仕様 → [E2E テスト] → Elm 整合性検証
+```mermaid
+flowchart LR
+    Rust["Rust (BFF)"] --> utoipa
+    utoipa --> OpenAPI["OpenAPI 仕様"]
+    OpenAPI --> E2ETest["E2E テスト"]
+    E2ETest --> Elm["Elm 整合性検証"]
 ```
 
 1. utoipa が Rust の型から OpenAPI を自動生成
@@ -201,4 +205,4 @@ Rust (BFF) → [utoipa] → OpenAPI 仕様 → [E2E テスト] → Elm 整合性
 - Issue #137: API 仕様と実装の整合性担保（OpenAPI / BFF / Elm）
 - PR #444: utoipa 導入による OpenAPI Code First 移行
 - ADR-025: 情報管理とローカル知識集約の方針
-- セッションログ: [prompts/runs/2026-02/2026-02-15_1140_ElmOpenAPIクライアント生成ツール評価.md](../../prompts/runs/2026-02/2026-02-15_1140_ElmOpenAPIクライアント生成ツール評価.md)（作成予定）
+- セッションログ: [prompts/runs/2026-02/2026-02-15_1140_ElmOpenAPIクライアント生成ツール評価.md](../../prompts/runs/2026-02/2026-02-15_1140_ElmOpenAPIクライアント生成ツール評価.md)

--- a/prompts/runs/2026-02/2026-02-15_1140_ElmOpenAPIクライアント生成ツール評価.md
+++ b/prompts/runs/2026-02/2026-02-15_1140_ElmOpenAPIクライアント生成ツール評価.md
@@ -106,8 +106,12 @@ Phase 1 で導入した E2E テスト（Playwright）が BFF ↔ Elm の整合�
 
 ### 整合性担保の仕組み
 
-```
-Rust (BFF) → [utoipa] → OpenAPI 仕様 → [E2E テスト] → Elm 整合性検証
+```mermaid
+flowchart LR
+    Rust["Rust (BFF)"] --> utoipa
+    utoipa --> OpenAPI["OpenAPI 仕様"]
+    OpenAPI --> E2ETest["E2E テスト"]
+    E2ETest --> Elm["Elm 整合性検証"]
 ```
 
 1. utoipa が Rust の型から OpenAPI を自動生成（PR #444 で完了）


### PR DESCRIPTION
## Issue

Closes #137

## Summary

Elm OpenAPI クライアント自動生成ツールを評価した結果、Cookie 認証が非サポートのため採用を見送った。

- 評価ツール: elm-open-api-cli v0.7.0
- 問題点: Cookie 認証（`apiKey in: cookie`）が非サポート
- 決定: 手動デコーダー + E2E テストでの整合性検証を継続

## Changes

- ADR-047: Elm OpenAPI クライアント自動生成の見送り
- セッションログ: 評価プロセスと判断の記録

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | ADR の完全性 | OK | コンテキスト、決定、理由、代替案、結果が記載されている |
| 2 | セッションログの正確性 | OK | 評価プロセス、判断ログ、成果物が正確に記録されている |
| 3 | Issue との整合性 | OK | Issue #137 がクローズされ、Phase 2 Step 3-4 完了が記録されている |
| 4 | 用語の統一 | OK | Cookie 認証の説明が一貫している |

## Test plan

- [x] ADR が適切に記載されている
- [x] セッションログが評価内容を正確に記録している
- [x] Issue #137 がクローズされている

🤖 Generated with [Claude Code](https://claude.com/claude-code)