### PR TITLE
#541 Update .git-blame-ignore-revs with squash merge hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Rustfmt standardization: comprehensive settings based on best practices
-c47998301859a4dd05ff4cb2dec4e9e4e4cb1cbb
+eea30fd8efdf1935d6ba9275a98ae2cea5d20ca0


### PR DESCRIPTION
## Issue

Related to #541

## Summary

squash merge 後のコミットハッシュ (`eea30fd`) で `.git-blame-ignore-revs` を更新する。

PR #553 の squash merge により、ブランチ内コミット (`c479983`) は main に存在しなくなったため、
正しい squash merge コミットのハッシュに差し替える。

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | ハッシュの正確性 | OK | `git log --oneline -1 origin/main` で `eea30fd` を確認 |

## Test plan

- [ ] `git blame` で `.git-blame-ignore-revs` が正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)