### PR TITLE
Fix orphaned Docker volumes on worktree cleanup

### DIFF
--- a/justfile
+++ b/justfile
@@ -527,12 +527,10 @@ worktree-remove name:
 
     echo "worktree を削除中: {{name}}"
 
-    # Docker コンテナを停止・削除
-    containers=$(docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml ps -q 2>/dev/null || true)
-    if [[ -n "$containers" ]]; then
-        echo "  Docker コンテナを停止中..."
-        docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down -v
-    fi
+    # Docker コンテナ・ボリュームを停止・削除
+    # コンテナが停止済みでもボリュームが残っている場合があるため、常に実行する
+    echo "  Docker リソースを削除中..."
+    docker compose --env-file .env -p "$PROJECT_NAME" -f infra/docker/docker-compose.yaml down -v 2>/dev/null || true
 
     # worktree を削除
     git worktree remove "$WORKTREE_PATH" --force

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -108,13 +108,11 @@ else
         fi
 
         if [[ "$DRY_RUN" == false ]]; then
-            # Docker コンテナを停止・削除
+            # Docker コンテナ・ボリュームを停止・削除
+            # コンテナが停止済みでもボリュームが残っている場合があるため、常に実行する
             project_name="ringiflow-${name}"
-            containers=$(docker compose -p "$project_name" -f infra/docker/docker-compose.yaml ps -q 2>/dev/null || true)
-            if [[ -n "$containers" ]]; then
-                echo "      Docker コンテナを停止中..."
-                docker compose -p "$project_name" -f infra/docker/docker-compose.yaml down -v 2>/dev/null || true
-            fi
+            echo "      Docker リソースを削除中..."
+            docker compose -p "$project_name" -f infra/docker/docker-compose.yaml down -v 2>/dev/null || true
 
             # ワークツリーを削除
             git worktree remove "$path" --force 2>/dev/null || true


### PR DESCRIPTION
## Issue

なし

## 概要

ワークツリー削除時（`just cleanup` / `just worktree-remove`）に、Docker の named volume が孤立して残る問題を修正。

## 変更内容

`docker compose down -v` 実行前のコンテナ存在チェック（`ps -q`）を削除し、常に `down -v` を実行するように変更。

### 背景

従来はコンテナが存在する場合のみ `down -v` を実行していたが、先に `just dev-down`（`-v` なし）でコンテナを停止していた場合、ボリューム削除がスキップされていた。`docker compose down -v` はコンテナが存在しなくてもボリュームを検出・削除できるため、ガード条件は不要。

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `scripts/cleanup.sh` | コンテナ存在チェックを削除、常に `down -v` を実行 |
| `justfile` (`worktree-remove`) | 同上 |

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 安全性 | OK | `2>/dev/null \|\| true` で Docker project が存在しないケースも安全にスキップ |
| 2 | 一貫性 | OK | `cleanup.sh` と `worktree-remove` の両方を同じパターンに統一 |
| 3 | 既存動作 | OK | `--dry-run` の挙動に影響なし（`DRY_RUN == false` の分岐内のみ変更） |

## Test plan

- [ ] `just cleanup --dry-run` が正常に動作することを確認
- [ ] worktree がある状態で `just cleanup` を実行し、volume も削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)