### PR TITLE
#555 Enable test-utils feature for core-service integration tests

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "dotenvy",
  "itertools",
  "pretty_assertions",
+ "ringiflow-core-service",
  "ringiflow-domain",
  "ringiflow-infra",
  "ringiflow-shared",

--- a/backend/apps/core-service/Cargo.toml
+++ b/backend/apps/core-service/Cargo.toml
@@ -25,6 +25,7 @@ dotenvy.workspace = true
 itertools.workspace = true
 
 [dev-dependencies]
+ringiflow-core-service = { path = ".", features = ["test-utils"] }
 ringiflow-domain = { workspace = true, features = ["test-support"] }
 ringiflow-infra = { workspace = true, features = ["test-utils"] }
 tokio-test.workspace = true


### PR DESCRIPTION
## Issue

Closes #555

## 概要

`cargo sqlx prepare --check --workspace -- --all-targets` が `comment_integration_test.rs` のコンパイルエラーで失敗する問題を修正。

## 変更内容

`core-service` の `[dev-dependencies]` に自身を `test-utils` feature 付きで追加。

`tests/` ディレクトリの統合テストは別クレートとしてコンパイルされるため `#[cfg(test)]` が有効にならず、`test_utils` モジュールにアクセスできなかった。`test-utils` feature を dev-dependencies で有効にすることで解決。

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 修正の妥当性 | OK | Rust の cfg ゲートと統合テストの別クレートコンパイルの仕様に基づく正しい修正 |
| 2 | `cargo sqlx prepare --check` pass | OK | ローカルで確認済み |
| 3 | `just check-all` pass | OK | lint + test + sqlx check すべて通過、API テストも全24ファイル成功 |

## Test plan

- [x] `cargo sqlx prepare --check --workspace -- --all-targets` が成功すること
- [x] `just check-all` が通過すること（API テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)