### PR TITLE
Enable show_full_output for review workflow debugging

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -162,6 +162,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # workflow_run イベントでは track_progress はサポートされていない
           track_progress: false
+          # デバッグ: SDK エラーの詳細を確認するため一時的に有効化
+          show_full_output: true
           # Dependabot などの Bot からの PR を許可
           allowed_bots: "dependabot[bot]"
           prompt: |

--- a/.github/workflows/claude-rules-check.yaml
+++ b/.github/workflows/claude-rules-check.yaml
@@ -158,6 +158,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: false
+          # デバッグ: SDK エラーの詳細を確認するため一時的に有効化
+          show_full_output: true
           # Dependabot などの Bot からの PR を許可
           allowed_bots: "dependabot[bot]"
           prompt: |


### PR DESCRIPTION
## Issue

なし（デバッグ用の一時的な変更）

## Summary

Claude Auto Review と Claude Rules Check の両ワークフローが 09:50 JST 以降すべて失敗している。
`show_full_output: false`（デフォルト）のためエラー詳細が確認できないため、一時的に `true` に変更してデバッグ情報を取得する。

- `claude-auto-review.yaml`: `show_full_output: true` 追加
- `claude-rules-check.yaml`: `show_full_output: true` 追加

エラー原因特定後、`show_full_output: false` に戻す予定。

## Test plan

- [ ] マージ後、次の PR レビュー実行時にエラー詳細がログに出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)