### PR TITLE
Revert show_full_output debug flag in review workflows

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -162,8 +162,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # workflow_run イベントでは track_progress はサポートされていない
           track_progress: false
-          # デバッグ: SDK エラーの詳細を確認するため一時的に有効化
-          show_full_output: true
           # Dependabot などの Bot からの PR を許可
           allowed_bots: "dependabot[bot]"
           prompt: |

--- a/.github/workflows/claude-rules-check.yaml
+++ b/.github/workflows/claude-rules-check.yaml
@@ -158,8 +158,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: false
-          # デバッグ: SDK エラーの詳細を確認するため一時的に有効化
-          show_full_output: true
           # Dependabot などの Bot からの PR を許可
           allowed_bots: "dependabot[bot]"
           prompt: |


### PR DESCRIPTION
## Issue

なし

## Summary

#527 のレビューワークフローデバッグ時に追加した `show_full_output: true` フラグを削除する。
API レート制限エラーの原因特定が完了したため、デバッグフラグは不要。

## 変更内容

- `claude-auto-review.yaml`: `show_full_output: true` とデバッグコメントを削除
- `claude-rules-check.yaml`: 同上

## Test plan

- [x] YAML 構文に問題がないこと（CI lint で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)