### PR TITLE
Use latest remote main as worktree start point

### DIFF
--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -101,11 +101,14 @@ echo "  パス: $WORKTREE_PATH"
 echo "  ブランチ: ${BRANCH}"
 echo "  ポートオフセット: $port_offset（自動割り当て）"
 
-# worktree を追加（ブランチがなければ作成）
+# リモートの最新 main を取得
+git fetch origin main --quiet
+
+# worktree を追加（ブランチがなければ origin/main から作成）
 if git rev-parse --verify "${BRANCH}" >/dev/null 2>&1; then
     git worktree add "$WORKTREE_PATH" "${BRANCH}"
 else
-    git worktree add -b "${BRANCH}" "$WORKTREE_PATH"
+    git worktree add -b "${BRANCH}" "$WORKTREE_PATH" origin/main
 fi
 
 # .env を生成


### PR DESCRIPTION
## Issue

なし

## Summary

`worktree-add.sh` で新しいブランチを作成する際、起点を現在の HEAD ではなくリモートの最新 `origin/main` に変更。

- `git fetch origin main --quiet` を worktree 追加前に実行
- `git worktree add -b` の start-point に `origin/main` を指定

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 既存動作への影響 | OK | 既存ブランチの checkout パスは変更なし |
| 2 | スクリプトの動作 | OK | `--quiet` で出力をクリーンに保持 |

## Test plan

- [ ] `just worktree-add test feature/test-branch` で `origin/main` から分岐することを確認
- [ ] `just worktree-issue <number>` でも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)