### PR TITLE
#583 Add plan file check step to PR completion flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,12 +385,13 @@ Test plan: 単一 PR は実装テスト＋手動テスト手順を記載。Epic 
 
 1. 実装完了、`just check-all` 通過
 2. 収束確認完了（[zoom-rhythm.md](.claude/rules/zoom-rhythm.md)）
-3. Draft PR 作成（`gh pr create --draft`）
-4. `/wrap-up` でドキュメント整備
-5. wrap-up 完了の検証（`git -c core.quotepath=false diff --name-only main...HEAD | grep -E "^(prompts/runs/|prompts/improvements/|prompts/recipes/|docs/05_ADR/|docs/06_|docs/07_)"`）。なければ `/wrap-up` を実行
-6. base branch 同期確認（`git fetch origin main && git log HEAD..origin/main --oneline`、差分あれば rebase + `just check-all` で再確認）
-7. ユーザーに確認を求める（「Ready にしてよいですか？」）
-8. ユーザー承認後、`gh pr ready` で Ready にする
+3. 計画ファイル確認（`git status` で `prompts/plans/` に未コミットファイルがあれば、現在の作業との関連を確認してコミットする）
+4. Draft PR 作成（`gh pr create --draft`）
+5. `/wrap-up` でドキュメント整備
+6. wrap-up 完了の検証（`git -c core.quotepath=false diff --name-only main...HEAD | grep -E "^(prompts/runs/|prompts/improvements/|prompts/recipes/|docs/05_ADR/|docs/06_|docs/07_)"`）。なければ `/wrap-up` を実行
+7. base branch 同期確認（`git fetch origin main && git log HEAD..origin/main --oneline`、差分あれば rebase + `just check-all` で再確認）
+8. ユーザーに確認を求める（「Ready にしてよいですか？」）
+9. ユーザー承認後、`gh pr ready` で Ready にする
 
 **禁止:**
 


### PR DESCRIPTION
## Issue

Closes #583

## 概要

PR 完了フローに計画ファイル（`prompts/plans/`）の確認ステップを追加する。

## 背景

plan mode → コンテキストクリア → 実装 → PR 作成の流れで、計画ファイルが未コミットのまま残る構造的な問題があった（改善記録: `prompts/improvements/2026-02/2026-02-16_2301_planモード後のコンテキスト喪失による計画ファイルのコミット漏れ.md`）。

## 変更内容

- PR 完了フローのステップ 2（収束確認完了）と旧ステップ 3（Draft PR 作成）の間に、計画ファイル確認ステップを挿入
- 後続ステップの番号を 3→4, 4→5, ..., 8→9 に繰り下げ

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 参照の網羅性 | OK | PR 完了フローのステップ番号を参照する他ファイルなし（Grep で確認） |
| 2 | 用語の統一 | OK | 「計画ファイル」「`prompts/plans/`」は既存用法と一致 |
| 3 | 意図の明確さ | OK | いつ・何を・どう確認するかが明記されている |

## Test plan

- [x] 変更後の CLAUDE.md で PR 完了フローのステップ番号が 1-9 で連続している
- [x] 新ステップ 3 の内容が改善記録の対策案と一致している
- [x] 他のファイルにステップ番号への参照がないことを Grep で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)