### PR TITLE
Reorder check-all to run audit after tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -439,8 +439,10 @@ check-pre-push:
 check:
     ./scripts/check-parallel.sh
 
-# プッシュ前の全チェック（軽量チェック + セキュリティ + API テスト + E2E テスト）
-check-all: check audit test-api test-e2e
+# プッシュ前の全チェック（軽量チェック + API テスト + E2E テスト + セキュリティ）
+# audit を最後に配置: cargo deny が取得するパッケージキャッシュのロックが
+# 後続の cargo build に影響し、サービス起動タイムアウトを引き起こすため (#596)
+check-all: check test-api test-e2e audit
 
 # OpenAPI 仕様書を utoipa から生成して openapi/openapi.yaml に出力
 openapi-generate:


### PR DESCRIPTION
## Issue

Closes #596

## 概要

`just check-all` の実行順序を変更し、`audit`（`cargo deny check`）をテスト後に実行するようにした。

### 変更内容

```diff
- check-all: check audit test-api test-e2e
+ check-all: check test-api test-e2e audit
```

### 背景

`check` 内の `sqlx prepare --check` がビルドアーティファクトを変更した後、`audit`（`cargo deny check`）がパッケージキャッシュのロックを取得する。この状態で `test-api` の `cargo build` が実行されると、ロック待機 + 再コンパイルにより 30 秒のヘルスチェックタイムアウトを超える場合があった。

`audit` はテスト結果に依存しないため、最後に移動しても品質ゲートとしての機能は変わらない。

## Test plan

- [ ] `just check-all` が安定して通過することを確認

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 品質ゲート機能の維持 | OK | `audit` は他のステップと独立しており、順序変更による機能的影響なし |
| 2 | 既存パターン整合 | OK | CI では各ステップが既に分離されており、順序の制約はない |

🤖 Generated with [Claude Code](https://claude.com/claude-code)