### PR TITLE
Fix missing DYNAMODB_PORT in worktree env cleanup

### DIFF
--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -122,7 +122,7 @@ if [[ "$NO_SETUP" == false ]]; then
     # 親プロセス（メインリポジトリの just）から継承されたポート環境変数をクリアする。
     # just の dotenv-load は既存の環境変数を上書きしないため、
     # クリアしないと worktree の .env ではなくメインの .env の値が使われてしまう。
-    env -u POSTGRES_PORT -u REDIS_PORT -u BFF_PORT -u VITE_PORT just setup-worktree
+    env -u POSTGRES_PORT -u REDIS_PORT -u DYNAMODB_PORT -u BFF_PORT -u VITE_PORT just setup-worktree
 else
     echo ""
     echo "（--no-setup: セットアップをスキップしました）"


### PR DESCRIPTION
## Issue

なし（worktree 作成時のバグ修正）

## 概要

`scripts/worktree-add.sh` で worktree セットアップ時に親プロセスの環境変数をクリアする `env -u` リストに `DYNAMODB_PORT` が含まれていなかった。

これにより、親プロセス（メインリポジトリの `just`）から `DYNAMODB_PORT=18000` が子プロセスに漏れ、worktree 固有の `.env`（例: `DYNAMODB_PORT=18400`）が無視され、DynamoDB コンテナのポート競合が発生していた。

## 変更内容

- `env -u` リストに `-u DYNAMODB_PORT` を追加

## Test plan

- [x] 既存テスト通過（pre-push hook）
- [ ] `just worktree-issue` で新規 worktree を作成し、DynamoDB コンテナがオフセット付きポートで起動することを確認

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 根本原因の特定 | OK | `env -u` リストと `.env` 変数の突合で `DYNAMODB_PORT` の漏れを確認 |
| 2 | 修正の妥当性 | OK | 他の変数（POSTGRES_PORT, REDIS_PORT, BFF_PORT, VITE_PORT）と同じパターン |

🤖 Generated with [Claude Code](https://claude.com/claude-code)