### PR TITLE
#608 Remove redundant commit confirmation from wrap-up skill

### DIFF
--- a/.claude/skills/wrap-up/SKILL.md
+++ b/.claude/skills/wrap-up/SKILL.md
@@ -140,11 +140,10 @@ ls prompts/plans/ | grep -v '^[0-9]' | grep -v README
 git mv prompts/plans/clever-napping-panda.md prompts/plans/288_dev-auth-feature-flag.md
 ```
 
-### Step 5: 確認と仕上げ
+### Step 5: コミットと仕上げ
 
-1. 作成したドキュメントの一覧を提示
-2. コミットするかユーザーに確認
-3. コミットメッセージの例:
+1. 作成したドキュメントの一覧を提示し、コミットする
+2. コミットメッセージの例:
    - `Add session log for <トピック>`
    - `Add ADR-NNN: <タイトル>`
    - `Add knowledge base entry for <技術名>`


### PR DESCRIPTION
## Issue

Closes #608

## 概要

wrap-up スキルの Step 5 から冗長なコミット確認を削除。

Step 2 でドキュメント作成を承認済みのため、Step 5 で再度コミット確認を求める必要がない。

## 変更内容

- Step 5 のタイトルを「確認と仕上げ」→「コミットと仕上げ」に変更
- 「コミットするかユーザーに確認」の手順を削除
- ドキュメント一覧提示とコミットを一つの手順に統合

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 意図の明確さ | OK | Step 2 の承認がコミットまで包含する前提が自然 |
| 2 | 既存フローとの整合 | OK | Step 2 の承認 → Step 3-4 作成 → Step 5 コミットの流れが一貫 |
| 3 | 番号の連続性 | OK | リスト番号が 1, 2 で連続 |

## Test plan

- [ ] `/wrap-up` を実行し、Step 5 でコミット確認なしにコミットされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)