### PR TITLE
Update SDD knowledge base with Spec Kit v0.1.0 and Harness Engineering

### DIFF
--- a/docs/06_ナレッジベース/methodology/独自フレームワークと既知手法の対応.md
+++ b/docs/06_ナレッジベース/methodology/独自フレームワークと既知手法の対応.md
@@ -157,21 +157,71 @@ ringiflow の独自性: 静的型付き言語（Rust / Elm）に特化した形�
 
 ### Spec-Driven Development（GitHub Spec Kit）
 
-GitHub が 2025 年後半に OSS 公開した開発手法。Intent → Spec → Plan → Tasks → Implement → PR のパイプラインで、仕様を中心に開発を進める。
+GitHub が 2025 年後半に OSS 公開した開発手法。Spec Kit v0.1.0（2026-01-28）で 8 つのコマンドから成るパイプラインに拡張された。仕様を中心に開発を進め、AI エージェントのスラッシュコマンドとしてパッケージ化している点が特徴。
 
-ringiflow の対応:
-- Intent = 要件定義書
-- Spec = 詳細設計書 + OpenAPI 仕様書
-- Plan = plan mode での設計
-- Tasks = Issue のチェックリスト
-- Implement = TDD 実装
-- PR = PR フロー
+#### パイプラインの対応関係
 
-ringiflow の独自性: 収束確認チェックリスト、設計ブラッシュアップループ、Self-review セクションなど、SDD にはない品質保証の仕組みを持つ。
+| SDD コマンド | 役割 | ringiflow の対応 |
+|-------------|------|-----------------|
+| Constitution | プロジェクトの不変原則を定義 | CLAUDE.md + `.claude/rules/` |
+| Specify | Intent → 仕様化（WHAT と WHY） | 要件定義書 + Issue 精査（Want 分析） |
+| Clarify | 仕様の曖昧さを質問で解消 | 設計ブラッシュアップループ |
+| Plan | 技術計画（アーキテクチャ、API 契約） | plan mode + 計画ファイル |
+| Checklist | ドメインカバレッジ検証 | 品質チェックリスト |
+| Tasks | 具体的タスクへの分解 | Phase 分割 + テストリスト |
+| Analyze | 全成果物の一貫性検証 | 収束確認チェックリスト |
+| Implement | タスクに基づく実装 | TDD 開発フロー |
+
+初回調査時（2026-02-06）は基本パイプライン（Intent → Spec → Plan → Tasks → Implement → PR）のみだったが、v0.1.0 で Constitution・Clarify・Checklist・Analyze が追加された。これら 4 つは ringiflow が既に独自に構築していた仕組みと強い対応を持つ。
+
+#### 3つの実装レベル（Bockeler）
+
+Martin Fowler のシリーズで Birgitta Bockeler が定義した 3 段階:
+
+| レベル | 名称 | 仕様の位置づけ |
+|--------|------|---------------|
+| 1 | Spec-First | 仕様を書いて実装するが、実装後に仕様は放棄 |
+| 2 | Spec-Anchored | 仕様が維持され、機能進化のアンカーとなる |
+| 3 | Spec-as-Source | 仕様のみ人間が編集。コードは完全に生成 |
+
+ringiflow は Spec-Anchored レベルに位置する。要件定義書・設計書・OpenAPI が維持され、実装のアンカーとして機能する。Spec-as-Source は学習効果の最大化（理念1）と相反するため、意識的に選択しない。
+
+#### ringiflow の独自性
+
+Clarify と Analyze の対応箇所で特に差異が大きい:
+
+- Clarify: SDD はアドホックな質問形式。ringiflow のブラッシュアップループは「ギャップ発見の観点」を体系化し、欠陥の発見（マイナス→ゼロ）と品質の向上（ゼロ→プラス）を区別する
+- Analyze: SDD は全成果物の一括クロスチェック。ringiflow はフェーズ別（設計・実装・テスト・横断検証）にチェックリストを分化
+
+| ringiflow 独自の仕組み | SDD に対応がないもの |
+|----------------------|---------------------|
+| 二つの砦（設計段階 + 品質ゲート） | 品質保証の二段構え |
+| 設計原則レンズ | TDD Refactor での設計品質評価 |
+| 問題解決フレームワーク | Want → To-Be → As-Is の構造的分析 |
+| Self-review セクション | PR 本文への収束確認結果の明示 |
+| 実装前の確認 | 型・API・パターンの事前検証 |
+
+| SDD 独自の仕組み | ringiflow に対応がないもの |
+|-----------------|--------------------------|
+| Skills 化（スラッシュコマンド） | ワークフローステップの AI コマンド化 |
+| Handoffs | コマンド間の機械可読な引き継ぎ |
+| Extension System | 外部ツールとのプラグイン統合 |
+
+#### 関連: Harness Engineering（Fowler, 2026-02）
+
+同じ Fowler シリーズで提唱された AI エージェントの品質維持フレームワーク。SDD と補完的に位置づけられる。
+
+| 要素 | 内容 | ringiflow の対応 |
+|------|------|-----------------|
+| Context Engineering | コードベース内のナレッジ強化 | CLAUDE.md、rules、手順書、ナレッジベース |
+| Architectural Constraints | 決定論的リンター・構造テスト | `just check-all`、lefthook |
+| Garbage Collection | 定期エージェント実行で不整合検出 | `/assess`（月次）、`/retro`（週次） |
 
 参考リソース:
 - [GitHub Spec Kit](https://github.com/github/spec-kit)
-- [Martin Fowler: Understanding SDD tools](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html)
+- [Fowler: Understanding SDD tools](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html)
+- [Fowler: Context Engineering for Coding Agents](https://martinfowler.com/articles/exploring-gen-ai/context-engineering-coding-agents.html)
+- [Fowler: Harness Engineering](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html)
 
 ## 設計原則レンズ（UI/UX）と既知手法
 
@@ -256,7 +306,9 @@ ringiflow の対応: CLAUDE.md の品質戦略を V&V の2層構造で整理し�
 - Martin, R. C. (2021) "Clean Craftsmanship" (nano-cycle)
 - Freeman, S. & Pryce, N. (2009) "Growing Object-Oriented Software, Guided by Tests"
 - [GitHub Spec Kit](https://github.com/github/spec-kit)
-- [Martin Fowler: Understanding SDD tools](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html)
+- [Fowler: Understanding SDD tools](https://martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html)
+- [Fowler: Context Engineering for Coding Agents](https://martinfowler.com/articles/exploring-gen-ai/context-engineering-coding-agents.html)
+- [Fowler: Harness Engineering](https://martinfowler.com/articles/exploring-gen-ai/harness-engineering.html)
 - Nielsen, J. (1994, 2024 更新) "10 Usability Heuristics for User Interface Design", Nielsen Norman Group
 - W3C (2018) "Web Content Accessibility Guidelines (WCAG) 2.1"
 - Wertheimer, M. (1923) "Laws of Organization in Perceptual Forms" (ゲシュタルト原則)
@@ -267,6 +319,7 @@ ringiflow の対応: CLAUDE.md の品質戦略を V&V の2層構造で整理し�
 
 | 日付 | 変更内容 |
 |------|---------|
+| 2026-02-18 | SDD セクションを大幅更新。パイプライン詳細対応、3 実装レベル、Harness Engineering を追加 |
 | 2026-02-18 | 設計原則レンズ（UI/UX）セクションを追加。Nielsen's Heuristics, WCAG 2.1 POUR, ゲシュタルト原則（#644） |
 | 2026-02-18 | nano-cycle と二層の Red モデルセクションを追加（#637） |
 | 2026-02-11 | V&V（品質戦略）セクションを追加（#438） |


### PR DESCRIPTION
## Issue

なし（ナレッジベース定期更新）

## Summary

SDD（Spec-Driven Development）セクションを Spec Kit v0.1.0 の最新状態に更新。
2026-02-06 の初回調査以降の変化を反映し、ringiflow との対応関係を詳細化。

## Changes

- パイプライン対応表を 8 コマンドに拡張（Constitution, Clarify, Checklist, Analyze を追加）
- Bockeler の 3 実装レベル（Spec-First / Spec-Anchored / Spec-as-Source）を追加し、ringiflow を Spec-Anchored と位置づけ
- 独自性の双方向比較（ringiflow → SDD にない仕組み 5 項目、SDD → ringiflow にない仕組み 3 項目）
- Harness Engineering フレームワーク（Context Engineering / Architectural Constraints / Garbage Collection）との対応を追加
- 関連リソースに Fowler シリーズ記事 2 件を追加

## Test plan

- [x] ドキュメントのみの変更（コード変更なし）
- [x] Markdown 構文エラーなし
- [x] 既存セクション構造との整合確認済み
- [x] 変更履歴エントリ追加済み

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 参照の網羅性 | OK | SDD の最新コマンド 8 つすべてを対応表に記載。Fowler シリーズの関連記事を参照リソースに追加 |
| 2 | 事実の正確性 | OK | Spec Kit v0.1.0 リリース日、各コマンドの役割を GitHub リポジトリと Fowler 記事で確認 |
| 3 | 既存構造との整合 | OK | セクション構成（概要 → 対応 → 独自性 → 参考リソース）を既存パターンに準拠 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)