### PR TITLE
Remove --delete-branch from gh pr merge commands

### DIFF
--- a/.claude/skills/review-and-merge/SKILL.md
+++ b/.claude/skills/review-and-merge/SKILL.md
@@ -355,7 +355,7 @@ gh pr checks
 #### マージ実行
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge --squash
 just clean-branches
 ```
 
@@ -368,11 +368,11 @@ just clean-branches
 
 #### `gh pr merge` 失敗時の対応
 
-`gh pr merge --squash --delete-branch` が失敗した場合、`--auto` にフォールバックせず以下の手順で対応する:
+`gh pr merge --squash` が失敗した場合、`--auto` にフォールバックせず以下の手順で対応する:
 
 1. エラーメッセージから原因を特定する
 2. 原因を解消する（下表参照）
-3. 解消後、`gh pr merge --squash --delete-branch` を再試行する
+3. 解消後、`gh pr merge --squash` を再試行する
 
 | 原因 | 対応 |
 |------|------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,8 +440,8 @@ gh pr ready     # Draft を解除
 → 詳細チェックリスト: [手順書: 品質ゲートと Ready for Review](docs/04_手順書/04_開発フロー/01_Issue駆動開発.md#6-品質ゲートと-ready-for-review)
 
 ```bash
-gh pr merge --squash --delete-branch
-just clean-branches  # マージ後のローカルブランチ削除
+gh pr merge --squash
+just clean-branches  # マージ後のブランチ削除（worktree のリセット含む）
 ```
 
 **禁止:** `--admin` で CI バイパス、CI 失敗状態での強制マージ
@@ -454,5 +454,5 @@ Claude Code Action による自動 PR レビューが有効。→ [`.github/work
 
 ```bash
 gh pr checks && gh pr view --comments  # 指摘対応フロー
-gh pr merge --squash --delete-branch   # 対応後マージ
+gh pr merge --squash                   # 対応後マージ
 ```

--- a/docs/04_手順書/04_開発フロー/01_Issue駆動開発.md
+++ b/docs/04_手順書/04_開発フロー/01_Issue駆動開発.md
@@ -563,7 +563,8 @@ Claude Code Action による自動レビューが実行される。
 レビュー確認後、手動でマージする。
 
 ```bash
-gh pr merge --squash --delete-branch
+gh pr merge --squash
+just clean-branches
 ```
 
 **Squash マージの効果:**
@@ -573,13 +574,7 @@ gh pr merge --squash --delete-branch
 
 → 設定詳細: [GitHub 設定 > Pull Requests](../02_プロジェクト構築/03_GitHub設定.md#13-pull-requests)
 
-注意: `--auto` は使用しない。レビュー結果を確認してからマージすること。
-
-**マージ後のローカルブランチ削除:**
-
-```bash
-just clean-branches
-```
+注意: `--auto` は使用しない。レビュー結果を確認してからマージすること。リモートブランチは GitHub の auto-delete 設定で自動削除される。
 
 ### 9. 振り返り
 

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -61,7 +61,6 @@ while IFS= read -r line; do
             reason=""
 
             # secondary worktree が main をチェックアウトしている場合
-            # （gh pr merge --delete-branch 等でフォールバックした結果）
             if [[ "$wt_branch" == "main" ]]; then
                 reason="main ブランチをチェックアウト中（不要な worktree）"
             fi


### PR DESCRIPTION
## Issue

なし

## Summary

- Worktree 環境で `gh pr merge --delete-branch` がローカルブランチ削除に失敗する問題を解消
- リモートブランチ削除は GitHub の auto-delete 設定（`delete_branch_on_merge: true`）に委譲
- ローカルブランチ整理は `just clean-branches`（`cleanup.sh`）に一元化

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 参照の網羅性 | OK | `gh pr merge --delete-branch` の全出現箇所を Grep で確認、履歴ファイル（improvements, plans）以外を更新 |
| 2 | 一貫性 | OK | 3ファイルとも `gh pr merge --squash` + `just clean-branches` の同一パターン |
| 3 | 機能的影響 | OK | `delete_branch_on_merge: true` を API で確認済み。リモート削除は auto-delete でカバー |

🤖 Generated with [Claude Code](https://claude.com/claude-code)