### PR TITLE
Add DynamoDB to tech stack and architecture diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ RingiFlow: 承認フロー・タスク管理・ドキュメント管理を一元
 |---------|------|
 | バックエンド | Rust + axum（BFF / Core Service / Auth Service） |
 | フロントエンド | Elm |
-| インフラ | AWS（ECS Fargate, Aurora PostgreSQL, ElastiCache Redis） |
+| インフラ | AWS（ECS Fargate, Aurora PostgreSQL, ElastiCache Redis, DynamoDB） |
 | IaC | Terraform |
 
 ## 開発コマンド

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@ https://demo.ka2kama.com
 |---------|------|----------|
 | バックエンド | **Rust** + axum | 型安全性、メモリ安全性、高パフォーマンス |
 | フロントエンド | **Elm** | 純粋関数型、ランタイムエラーゼロ、The Elm Architecture |
-| データストア | PostgreSQL, Redis | ワークフロー・ユーザー管理、セッション管理 |
+| データストア | PostgreSQL, Redis, DynamoDB | ワークフロー・ユーザー管理、セッション管理、監査ログ |
 | インフラ | AWS Lightsail, Cloudflare | デモ環境（個人開発向け低コスト構成） |
 
 ## アーキテクチャ
@@ -43,12 +43,14 @@ flowchart LR
     subgraph Data
         PG["PostgreSQL"]
         Redis["Redis<br/>(Session)"]
+        DynamoDB["DynamoDB<br/>(Audit Log)"]
     end
 
     Browser --> BFF
     BFF --> Core
     BFF --> Auth
     BFF --> Redis
+    BFF --> DynamoDB
     Core --> PG
     Auth --> PG
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://demo.ka2kama.com
 |-------|-----------|-----------|
 | Backend | **Rust** + axum | Type safety, memory safety, high performance |
 | Frontend | **Elm** | Pure functional, zero runtime errors, The Elm Architecture |
-| Data stores | PostgreSQL, Redis | Workflow & user management, session management |
+| Data stores | PostgreSQL, Redis, DynamoDB | Workflow & user management, session management, audit logs |
 | Infrastructure | AWS Lightsail, Cloudflare | Demo environment (low-cost setup for solo development) |
 
 ## Architecture
@@ -43,12 +43,14 @@ flowchart LR
     subgraph Data
         PG["PostgreSQL"]
         Redis["Redis<br/>(Session)"]
+        DynamoDB["DynamoDB<br/>(Audit Log)"]
     end
 
     Browser --> BFF
     BFF --> Core
     BFF --> Auth
     BFF --> Redis
+    BFF --> DynamoDB
     Core --> PG
     Auth --> PG
 ```


### PR DESCRIPTION
## Issue

なし

## Summary

DynamoDB（監査ログ用）が README および CLAUDE.md の技術スタック・アーキテクチャ図から欠落していたため追加。

変更箇所:
- README.md / README.ja.md: Tech Stack テーブルに DynamoDB 追加、Architecture 図に DynamoDB ノードと BFF → DynamoDB 接続を追加
- CLAUDE.md: インフラ行に DynamoDB 追加

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | 接続元の正確性 | OK | `backend/apps/bff/src/config.rs` で DynamoDB エンドポイントを設定しており、BFF からの接続で正しい |
| 2 | EN/JA の整合 | OK | 両 README で同一の変更 |
| 3 | 既存ドキュメント整合 | OK | ADR-045、アーキテクチャ設計書と矛盾なし |

## Test plan

- [ ] README.md のアーキテクチャ図が GitHub 上で正常にレンダリングされることを確認
- [ ] README.ja.md の同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)