### PR TITLE
#680 Enforce impl-docs naming convention in CI

### DIFF
--- a/docs/07_実装解説/PR536_WorkflowTestBuilder/01_WorkflowTestBuilder_コード解説.md
+++ b/docs/07_実装解説/PR536_WorkflowTestBuilder/01_WorkflowTestBuilder_コード解説.md
@@ -364,7 +364,7 @@ test-utils = [
 
 ## 設計解説
 
-コード実装レベルの判断を記載する。機能・仕組みレベルの判断は[機能解説](./01_機能解説.md#設計判断)を参照。
+コード実装レベルの判断を記載する。機能・仕組みレベルの判断は[機能解説](./01_WorkflowTestBuilder_機能解説.md#設計判断)を参照。
 
 ### 1. Arc<dyn Trait> による trait object パターン
 
@@ -487,7 +487,7 @@ pub mod test_utils;
 
 ## 関連ドキュメント
 
-- [機能解説](./01_機能解説.md)
+- [機能解説](./01_WorkflowTestBuilder_機能解説.md)
 - [計画ファイル](../../../prompts/plans/525_phase1-workflow-test-builder.md)
 - [セッションログ](../../../prompts/runs/2026-02/2026-02-15_1137_Phase1-WorkflowTestBuilder実装.md)
 - [`WorkflowTestBuilder` ソースコード](../../../backend/apps/core-service/src/test_utils/workflow_test_builder.rs)

--- a/docs/07_実装解説/PR536_WorkflowTestBuilder/01_WorkflowTestBuilder_機能解説.md
+++ b/docs/07_実装解説/PR536_WorkflowTestBuilder/01_WorkflowTestBuilder_機能解説.md
@@ -280,7 +280,7 @@ sequenceDiagram
 
 ## 設計判断
 
-機能・仕組みレベルの判断を記載する。コード実装レベルの判断は[コード解説](./01_コード解説.md#設計解説)を参照。
+機能・仕組みレベルの判断を記載する。コード実装レベルの判断は[コード解説](./01_WorkflowTestBuilder_コード解説.md#設計解説)を参照。
 
 ### 1. 統合テストを tests/ に配置するか、既存ユニットテストを書き換えるか
 
@@ -317,7 +317,7 @@ WorkflowTestSetup が複数の Mock リポジトリを保持する必要があ�
 
 ## 関連ドキュメント
 
-- [コード解説](./01_コード解説.md)
+- [コード解説](./01_WorkflowTestBuilder_コード解説.md)
 - [計画ファイル](../../../prompts/plans/525_phase1-workflow-test-builder.md)
 - [セッションログ](../../../prompts/runs/2026-02/2026-02-15_1137_Phase1-WorkflowTestBuilder実装.md)
 - Issue #525: Core Service ユースケース層のクローン削減・ファイルサイズ削減

--- a/scripts/check/impl-docs.sh
+++ b/scripts/check/impl-docs.sh
@@ -77,9 +77,7 @@ if [ ${#ERRORS[@]} -gt 0 ]; then
     for error in "${ERRORS[@]}"; do
         echo "  - $error"
     done
-    # 警告のみ（exit 0）: 既存の違反がある場合にブロックしない
-    # 修正後に exit 1 に切り替える
-    exit 0
+    exit 1
 fi
 
 echo "✅ 実装解説のファイル命名規則に準拠しています"


### PR DESCRIPTION
## Issue

Closes #680

## 概要

実装解説の命名規則チェックスクリプト (`scripts/check/impl-docs.sh`) を警告のみ（`exit 0`）から CI ブロック（`exit 1`）に切り替えた。

前提条件として、既存の命名規則違反（`PR536_WorkflowTestBuilder/` 内のファイル名）を修正した。

## 変更内容

- `01_コード解説.md` → `01_WorkflowTestBuilder_コード解説.md` にリネーム
- `01_機能解説.md` → `01_WorkflowTestBuilder_機能解説.md` にリネーム
- ファイル間の相互参照リンクを更新
- `scripts/check/impl-docs.sh` の `exit 0` を `exit 1` に変更

## Test plan

- [x] `bash scripts/check/impl-docs.sh` が正常終了（exit 0）することを確認
- [ ] `just check-all` が通過することを確認（CI で検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)