### PR TITLE
#701 Add mise trust step to setup recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ default:
 # 順序: ツール確認 → 環境変数 → Git フック → Docker 起動 → DB マイグレーション → 依存関係ビルド
 # ※ sqlx の query! マクロはコンパイル時に DB スキーマを検証するため、
 #    マイグレーション完了後に cargo build を実行する必要がある
-setup: check-tools setup-env setup-hooks dev-deps setup-db setup-root-deps setup-deps
+setup: setup-mise check-tools setup-env setup-hooks dev-deps setup-db setup-root-deps setup-deps
     @echo ""
     @echo "✓ セットアップ完了"
     @echo "  - just dev-all         : 全サーバー一括起動（推奨）"
@@ -28,6 +28,10 @@ setup: check-tools setup-env setup-hooks dev-deps setup-db setup-root-deps setup
     @echo "  - just dev-core-service: Core Service 起動"
     @echo "  - just dev-auth-service: Auth Service 起動"
     @echo "  - just dev-web         : フロントエンド起動"
+
+# mise の設定ファイルを信頼済みにする（mise がインストール済みの場合のみ）
+setup-mise:
+    @which mise > /dev/null 2>&1 && mise trust || true
 
 # 開発ツールのインストール確認
 check-tools:


### PR DESCRIPTION
## Issue

Closes #701

## 概要

PR #700 で Volta → mise に移行した際、`mise trust` ステップが `just setup` に含まれていなかった。
初回クローン後に `.mise.toml` が信頼されず、mise 管理のツールバージョンが有効にならない問題を修正。

## 変更内容

- `justfile` に `setup-mise` レシピを追加（`mise` がインストール済みの場合のみ `mise trust` を実行）
- `setup` レシピの依存チェーンの先頭に `setup-mise` を配置

## Self-review

| # | 観点 | 判定 | 確認内容 |
|---|------|------|---------|
| 1 | mise 未使用環境への影響 | OK | `which mise` で存在確認し、未インストール時はスキップ |
| 2 | 冪等性 | OK | 信頼済みの場合は WARN のみで正常終了 |
| 3 | `just check-all` pass | OK | pre-push フックで確認済み |

## Test plan

- [x] `just setup-mise` が mise インストール済み環境で正常動作すること
- [x] pre-push フック（`just check-pre-push`）が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)