### PR TITLE
Fix Mermaid syntax errors across documentation

### DIFF
--- a/docs/01_要件定義書/機能仕様書/04_ワークフローデザイナー.md
+++ b/docs/01_要件定義書/機能仕様書/04_ワークフローデザイナー.md
@@ -103,7 +103,7 @@ flowchart LR
 flowchart TB
     subgraph layout["デザイナー画面"]
         direction TB
-        TB["ツールバー: 保存 / バリデーション / 公開 / 戻る"]
+        Toolbar["ツールバー: 保存 / バリデーション / 公開 / 戻る"]
         subgraph main["メインエリア"]
             direction LR
             PA["ステップパレット<br/>○ 開始<br/>✓ 承認<br/>◎ 終了"]
@@ -112,7 +112,7 @@ flowchart TB
         end
         SB["ステータスバー: 下書き | 5ステップ | 最終保存: 15:30"]
     end
-    TB --- main --- SB
+    Toolbar --- main --- SB
 ```
 
 | エリア | 位置 | 内容 |

--- a/docs/06_ナレッジベース/elm/Elmルーティング.md
+++ b/docs/06_ナレッジベース/elm/Elmルーティング.md
@@ -94,7 +94,7 @@ sequenceDiagram
     participant Route as Route.elm
     participant Nav as Browser.Navigation
 
-    User->>Browser: リンクをクリック<br/><a href="/workflows/new">
+    User->>Browser: リンクをクリック<br/>&lt;a href="/workflows/new"&gt;
     Browser->>Elm: onUrlRequest イベント
     Elm->>Elm: Msg = LinkClicked (Internal url)
 

--- a/docs/07_実装解説/PR114_ワークフロー申請機能/01_ワークフロー申請_機能解説.md
+++ b/docs/07_実装解説/PR114_ワークフロー申請機能/01_ワークフロー申請_機能解説.md
@@ -169,7 +169,7 @@ sequenceDiagram
     Core->>Core: DTO 変換 + ユーザー名解決
     Core-->>Client: 201 Created + JSON
     Client-->>BFF: WorkflowInstanceDto
-    BFF-->>Browser: ApiResponse<WorkflowData>
+    BFF-->>Browser: ApiResponse&lt;WorkflowData&gt;
 ```
 
 #### 処理ステップ

--- a/docs/07_実装解説/PR166_ダッシュボード/01_ダッシュボード_機能解説.md
+++ b/docs/07_実装解説/PR166_ダッシュボード/01_ダッシュボード_機能解説.md
@@ -120,9 +120,9 @@ sequenceDiagram
     Client->>Core: GET /internal/dashboard/stats?tenant_id=...&user_id=...
     Core->>UC: get_stats(tenant_id, user_id, now)
     UC->>Repo: find_by_assigned_to(tenant_id, user_id)
-    Repo-->>UC: Vec<WorkflowStep>
+    Repo-->>UC: Vec&lt;WorkflowStep&gt;
     UC->>Repo: find_by_initiated_by(tenant_id, user_id)
-    Repo-->>UC: Vec<WorkflowInstance>
+    Repo-->>UC: Vec&lt;WorkflowInstance&gt;
     UC->>UC: フィルタリング + カウント
     UC-->>Core: DashboardStats
     Core-->>Client: DashboardStatsDto

--- a/docs/07_実装解説/PR166_ダッシュボード/02_ダッシュボード_コード解説.md
+++ b/docs/07_実装解説/PR166_ダッシュボード/02_ダッシュボード_コード解説.md
@@ -167,7 +167,7 @@ sequenceDiagram
     Session-->>BFF: SessionData
     BFF->>Client: get_dashboard_stats(tenant_id, user_id)
     Client-->>BFF: DashboardStatsDto
-    BFF-->>Elm: ApiResponse<DashboardStatsData>
+    BFF-->>Elm: ApiResponse&lt;DashboardStatsData&gt;
 ```
 
 ```rust

--- a/docs/07_実装解説/PR228_ドメインモデル非決定的値排除/01_ドメインモデル非決定的値排除_機能解説.md
+++ b/docs/07_実装解説/PR228_ドメインモデル非決定的値排除/01_ドメインモデル非決定的値排除_機能解説.md
@@ -149,7 +149,7 @@ sequenceDiagram
     participant Inst as WorkflowInstance
 
     UC->>Clock: now()
-    Clock-->>UC: DateTime<Utc>
+    Clock-->>UC: DateTime&lt;Utc&gt;
     UC->>Step: WorkflowStep::new(NewWorkflowStep { ..., now })
     UC->>Step: step.activated(now)
     UC->>Inst: instance.submitted(now)

--- a/docs/07_実装解説/PR254_ユーザー検索UI/01_ユーザー検索UI_機能解説.md
+++ b/docs/07_実装解説/PR254_ユーザー検索UI/01_ユーザー検索UI_機能解説.md
@@ -61,8 +61,8 @@ sequenceDiagram
     BFF->>Core: GET /internal/users?tenant_id=...
     Core->>DB: SELECT ... FROM users WHERE tenant_id = $1 AND status = 'active'
     DB-->>Core: ユーザー一覧
-    Core-->>BFF: ApiResponse<Vec<UserItemDto>>
-    BFF-->>Elm: ApiResponse<Vec<UserItemData>>
+    Core-->>BFF: ApiResponse&lt;Vec&lt;UserItemDto&gt;&gt;
+    BFF-->>Elm: ApiResponse&lt;Vec&lt;UserItemData&gt;&gt;
 
     User->>Elm: テキスト入力（例: "山田"）
     Elm->>Elm: filterUsers("山田", users)
@@ -168,12 +168,12 @@ sequenceDiagram
     BFF->>Client: list_users(tenant_id)
     Client->>Core: GET /internal/users?tenant_id=...
     Core->>Repo: find_all_active_by_tenant(tenant_id)
-    Repo-->>Core: Vec<User>
+    Repo-->>Core: Vec&lt;User&gt;
     Core->>Core: User → UserItemDto（DisplayId 生成）
-    Core-->>Client: ApiResponse<Vec<UserItemDto>>
-    Client-->>BFF: ApiResponse<Vec<UserItemDto>>
+    Core-->>Client: ApiResponse&lt;Vec&lt;UserItemDto&gt;&gt;
+    Client-->>BFF: ApiResponse&lt;Vec&lt;UserItemDto&gt;&gt;
     BFF->>BFF: UserItemDto → UserItemData
-    BFF-->>Elm: ApiResponse<Vec<UserItemData>>
+    BFF-->>Elm: ApiResponse&lt;Vec&lt;UserItemData&gt;&gt;
     Elm->>Elm: デコード → List UserItem
 ```
 

--- a/docs/07_実装解説/PR254_ユーザー検索UI/02_ユーザー検索UI_コード解説.md
+++ b/docs/07_実装解説/PR254_ユーザー検索UI/02_ユーザー検索UI_コード解説.md
@@ -175,12 +175,12 @@ sequenceDiagram
     BFF->>Client: list_users(tenant_id)
     Client->>Core: GET /internal/users?tenant_id=...
     Core->>Repo: find_all_active_by_tenant(tenant_id)
-    Repo-->>Core: Vec<User>
+    Repo-->>Core: Vec&lt;User&gt;
     Core->>Core: UserItemDto::from_user（DisplayId 生成）
-    Core-->>Client: ApiResponse<Vec<UserItemDto>>
-    Client-->>BFF: ApiResponse<Vec<UserItemDto>>
+    Core-->>Client: ApiResponse&lt;Vec&lt;UserItemDto&gt;&gt;
+    Client-->>BFF: ApiResponse&lt;Vec&lt;UserItemDto&gt;&gt;
     BFF->>BFF: UserItemData::from(dto)
-    BFF-->>BFF: ApiResponse<Vec<UserItemData>>
+    BFF-->>BFF: ApiResponse&lt;Vec&lt;UserItemData&gt;&gt;
 ```
 
 ```rust

--- a/docs/07_実装解説/PR413_マルチテナントRLS/03_コネクション管理_機能解説.md
+++ b/docs/07_実装解説/PR413_マルチテナントRLS/03_コネクション管理_機能解説.md
@@ -178,7 +178,7 @@ sequenceDiagram
 
     Caller->>TC: acquire(&pool, &tenant_id)
     TC->>Pool: pool.acquire()
-    Pool-->>TC: PoolConnection<Postgres>
+    Pool-->>TC: PoolConnection&lt;Postgres&gt;
     TC->>PG: set_config('app.tenant_id', tenant_id, false)
     PG-->>TC: OK
     TC-->>Caller: TenantConnection

--- a/docs/07_実装解説/PR466_削除レジストリ基盤/01_削除レジストリ基盤_機能解説.md
+++ b/docs/07_実装解説/PR466_削除レジストリ基盤/01_削除レジストリ基盤_機能解説.md
@@ -71,7 +71,7 @@ sequenceDiagram
     DDB-->>Registry: DeletionResult
     Registry->>Redis: delete(tenant_id)
     Redis-->>Registry: DeletionResult
-    Registry-->>Caller: HashMap<name, DeletionResult>
+    Registry-->>Caller: HashMap&lt;name, DeletionResult&gt;
 ```
 
 ### 削除対象データストア

--- a/docs/07_実装解説/PR46_認証機能/01_認証機能_機能解説.md
+++ b/docs/07_実装解説/PR46_認証機能/01_認証機能_機能解説.md
@@ -156,7 +156,7 @@ sequenceDiagram
 
     BFF->>Redis: DEL session:{tenant_id}:{session_id}
     BFF->>Redis: DEL csrf:{tenant_id}:{session_id}
-    BFF-->>User: 200 OK + Set-Cookie: session_id=; Max-Age=0
+    BFF-->>User: 200 OK + Set-Cookie: session_id=#59; Max-Age=0
 ```
 
 ### フロー 3: CSRF 防御

--- a/docs/07_実装解説/PR479_多段階承認/01_多段階承認_機能解説.md
+++ b/docs/07_実装解説/PR479_多段階承認/01_多段階承認_機能解説.md
@@ -162,7 +162,7 @@ sequenceDiagram
     UC->>Repo: fetch instance (Draft)
     UC->>Repo: fetch definition
     UC->>Def: extract_approval_steps()
-    Def-->>UC: Vec<ApprovalStepDef>
+    Def-->>UC: Vec&lt;ApprovalStepDef&gt;
     UC->>UC: validate approvers ↔ steps
     UC->>UC: create steps (Active + Pending)
     UC->>UC: instance.with_current_step()
@@ -198,7 +198,7 @@ sequenceDiagram
     UC->>Repo: fetch instance
     UC->>Repo: fetch definition
     UC->>Def: extract_approval_steps()
-    Def-->>UC: Vec<ApprovalStepDef>
+    Def-->>UC: Vec&lt;ApprovalStepDef&gt;
     UC->>UC: find current position
     alt 次ステップあり（中間）
         UC->>Inst: advance_to_next_step()

--- a/docs/07_実装解説/PR487_コメント機能/01_ワークフローコメント_コード解説.md
+++ b/docs/07_実装解説/PR487_コメント機能/01_ワークフローコメント_コード解説.md
@@ -455,7 +455,7 @@ sequenceDiagram
     H->>M: get_session(session_manager, jar)
     H->>H: PostCommentCoreRequest 組立
     H->>C: post_comment(display_number, req)
-    C-->>H: Result<ApiResponse>
+    C-->>H: Result&lt;ApiResponse&gt;
     H->>H: エラーマッピング
 ```
 

--- a/docs/07_実装解説/PR487_コメント機能/01_ワークフローコメント_機能解説.md
+++ b/docs/07_実装解説/PR487_コメント機能/01_ワークフローコメント_機能解説.md
@@ -92,8 +92,8 @@ sequenceDiagram
     DB-->>Core: comments[]
     Core->>DB: SELECT users (posted_by の一括解決)
     DB-->>Core: user_names
-    Core-->>BFF: 200 OK + Vec<WorkflowCommentDto>
-    BFF-->>Browser: 200 OK + Vec<WorkflowCommentData>
+    Core-->>BFF: 200 OK + Vec&lt;WorkflowCommentDto&gt;
+    BFF-->>Browser: 200 OK + Vec&lt;WorkflowCommentData&gt;
 ```
 
 ## アーキテクチャ

--- a/docs/07_実装解説/PR488_差し戻し再申請/01_差し戻し再申請_コード解説.md
+++ b/docs/07_実装解説/PR488_差し戻し再申請/01_差し戻し再申請_コード解説.md
@@ -257,8 +257,8 @@ sequenceDiagram
     Client->>Core: POST /internal/.../request-changes
     Core->>UC: request_changes_step(input, step_id, tenant_id, user_id)
     UC-->>Core: WorkflowWithSteps
-    Core-->>Client: ApiResponse<WorkflowInstanceDto>
-    Client-->>BFF: ApiResponse<WorkflowInstanceDto>
+    Core-->>Client: ApiResponse&lt;WorkflowInstanceDto&gt;
+    Client-->>BFF: ApiResponse&lt;WorkflowInstanceDto&gt;
 ```
 
 #### リクエスト型の構成


### PR DESCRIPTION
## Summary

- Mermaid 図のパースエラーを 15 ファイル・33 箇所修正
- セミコロン `;` のエスケープ（`#59;`）: Cookie 値内のセミコロンが文終端として解釈される問題
- 方向キーワード `TB` のノード ID 衝突を `Toolbar` にリネーム
- 未エスケープの `<>` 型パラメータ（`Vec<User>` 等）を `&lt;`/`&gt;` でエスケープ（29 箇所）
- HTML `<a>` タグのエスケープ

## Self-review

- 参照の網羅性: Mermaid ブロック内の特殊文字を全ファイルスキャンで網羅
- 用語の統一: エスケープ方式を HTML エンティティ（`&lt;`/`&gt;`）に統一（PR197 の既存パターンに準拠）
- 意図の明確さ: レンダリング結果は変更前と同一、構文エラーのみ修正
- `just check-all` pass: pre-push hook で全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)