### PR TITLE
Fix Mermaid parse errors in implementation docs

### DIFF
--- a/docs/07_実装解説/PR310_テナント情報取得/02_テナント情報取得_コード解説.md
+++ b/docs/07_実装解説/PR310_テナント情報取得/02_テナント情報取得_コード解説.md
@@ -235,7 +235,7 @@ MeResponseData {
 ```mermaid
 flowchart LR
     JSON["/auth/me レスポンス"] --> Decoder["Decode.map5 User<br/>id, email, name, tenantId, roles"]
-    Decoder --> User["User { tenantId = \"...\" }"]
+    Decoder --> User["User { tenantId = #quot;...#quot; }"]
     User --> WithUser["withUser"]
     WithUser --> Shared["Shared.tenantId = user.tenantId"]
 ```

--- a/docs/07_実装解説/PR658_ログ初期化共通化/01_ログ初期化共通化_コード解説.md
+++ b/docs/07_実装解説/PR658_ログ初期化共通化/01_ログ初期化共通化_コード解説.md
@@ -58,7 +58,7 @@ flowchart LR
 
 ```mermaid
 flowchart TD
-    FROM_ENV["TracingConfig::from_env(\"bff\")"]
+    FROM_ENV["TracingConfig::from_env(#quot;bff#quot;)"]
     LF_ENV["LogFormat::from_env()"]
     ENV_VAR{"LOG_FORMAT\n環境変数"}
     PARSE["LogFormat::parse(val)"]

--- a/docs/07_実装解説/PR658_ログ初期化共通化/01_ログ初期化共通化_機能解説.md
+++ b/docs/07_実装解説/PR658_ログ初期化共通化/01_ログ初期化共通化_機能解説.md
@@ -113,13 +113,13 @@ flowchart LR
         OBS["LogFormat + TracingConfig\n+ init_tracing()"]
     end
     subgraph BFF["BFF main.rs"]
-        B2["TracingConfig::from_env(\"bff\")\ninit_tracing(config)"]
+        B2["TracingConfig::from_env(#quot;bff#quot;)\ninit_tracing(config)"]
     end
     subgraph Core["Core main.rs"]
-        C2["TracingConfig::from_env(\"core-service\")\ninit_tracing(config)"]
+        C2["TracingConfig::from_env(#quot;core-service#quot;)\ninit_tracing(config)"]
     end
     subgraph Auth["Auth main.rs"]
-        A2["TracingConfig::from_env(\"auth-service\")\ninit_tracing(config)"]
+        A2["TracingConfig::from_env(#quot;auth-service#quot;)\ninit_tracing(config)"]
     end
 
     OBS --> B2

--- a/docs/07_実装解説/PR668_PIIマスキング基盤/01_PIIマスキング_機能解説.md
+++ b/docs/07_実装解説/PR668_PIIマスキング基盤/01_PIIマスキング_機能解説.md
@@ -87,12 +87,12 @@ PII 型が `derive(Debug)` で平文出力していた。
 
 ```mermaid
 flowchart LR
-    Email["Email(\"user@example.com\")"]
+    Email["Email(#quot;user@example.com#quot;)"]
     Debug["Debug 出力"]
     Log["tracing ログ"]
 
     Email -->|"derive(Debug)"| Debug
-    Debug -->|"Email(\"user@example.com\")"| Log
+    Debug -->|"Email(#quot;user@example.com#quot;)"| Log
 ```
 
 制約・課題:
@@ -105,12 +105,12 @@ PII 型はカスタム `Debug` で `[REDACTED]` を出力し、`Display` は削�
 
 ```mermaid
 flowchart LR
-    Email["Email(\"user@example.com\")"]
+    Email["Email(#quot;user@example.com#quot;)"]
     Debug["カスタム Debug"]
     Log["tracing ログ"]
 
     Email -->|"カスタム Debug"| Debug
-    Debug -->|"Email(\"[REDACTED]\")"| Log
+    Debug -->|"Email(#quot;[REDACTED]#quot;)"| Log
 ```
 
 改善点:


### PR DESCRIPTION
## Summary

- 実装解説ドキュメント（PR310, PR658, PR668）の Mermaid フローチャートで、ノードラベル内のエスケープされたダブルクォート（`\"`）が Mermaid パーサーでエラーになっていた問題を修正
- `\"` を Mermaid の HTML エンティティ記法 `#quot;` に置換（4ファイル、9箇所）

## Self-review

- 参照の網羅性: `docs/` 全体を `\\\"` で Grep し、Mermaid ブロック内の全箇所を網羅的に修正済み
- 用語の統一: Mermaid エンティティ記法（`#quot;`）で統一
- 意図の明確さ: コミットメッセージに原因と修正方法を記載
- `just check-all` pass: pre-push hook で全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)