### PR TITLE
Optimize Rules Check by pre-computing path matching

### DIFF
--- a/.github/scripts/match-rules.py
+++ b/.github/scripts/match-rules.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""PR の変更ファイルにマッチする .claude/rules/ のルールを特定し、内容を出力する。
+
+使い方:
+    python3 match-rules.py <changed-files.txt>
+
+入力: 変更ファイル一覧（1 行 1 パス）
+出力: マッチしたルールの名前リスト + 各ルールの本文（フロントマター除去済み）
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def glob_to_regex(pattern: str) -> str:
+    """glob パターン（** 対応）を正規表現に変換する。
+
+    変換ルール:
+    - **/ → (?:.+/)? （0 個以上のディレクトリ）
+    - 末尾 ** → .* （任意のパス）
+    - * → [^/]* （単一セグメント内の任意文字列）
+    - ? → [^/] （単一セグメント内の任意 1 文字）
+    - その他の正規表現メタ文字はエスケープ
+    """
+    i = 0
+    regex: list[str] = []
+    n = len(pattern)
+
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                # ** パターン
+                if i + 2 < n and pattern[i + 2] == "/":
+                    # **/ → 0 個以上のディレクトリ
+                    regex.append("(?:.+/)?")
+                    i += 3
+                else:
+                    # 末尾 ** → 任意のパス
+                    regex.append(".*")
+                    i += 2
+            else:
+                # * → 単一セグメント内
+                regex.append("[^/]*")
+                i += 1
+        elif c == "?":
+            regex.append("[^/]")
+            i += 1
+        elif c in r".+^${}()|\\[]":
+            regex.append("\\" + c)
+            i += 1
+        else:
+            regex.append(c)
+            i += 1
+
+    return "^" + "".join(regex) + "$"
+
+
+def parse_frontmatter_paths(content: str) -> list[str]:
+    """YAML フロントマターから paths パターンを抽出する。
+
+    フォーマット:
+    ---
+    paths:
+      - "pattern1"
+      - "pattern2"
+    ---
+    """
+    lines = content.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return []
+
+    paths: list[str] = []
+    in_paths = False
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped == "paths:":
+            in_paths = True
+            continue
+        if in_paths and stripped.startswith("- "):
+            pattern = stripped[2:].strip().strip('"').strip("'")
+            paths.append(pattern)
+        elif in_paths and stripped and not stripped.startswith("- "):
+            break
+
+    return paths
+
+
+def strip_frontmatter(content: str) -> str:
+    """YAML フロントマターを除去してルール本文を返す。"""
+    lines = content.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return content
+
+    for i, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            return "\n".join(lines[i + 1 :]).lstrip("\n")
+
+    return content
+
+
+def match_rules(
+    changed_files: list[str], rules_dir: Path
+) -> list[tuple[str, str]]:
+    """変更ファイルにマッチするルールを返す。
+
+    Returns: [(ルールファイルパス, フロントマター除去済み本文), ...]
+    """
+    matched: list[tuple[str, str]] = []
+
+    for rule_file in sorted(rules_dir.glob("*.md")):
+        content = rule_file.read_text()
+        paths = parse_frontmatter_paths(content)
+
+        if not paths:
+            continue
+
+        # いずれかのパターンがいずれかの変更ファイルにマッチすればOK
+        rule_matched = False
+        for pattern in paths:
+            compiled = re.compile(glob_to_regex(pattern))
+            for f in changed_files:
+                if compiled.match(f):
+                    rule_matched = True
+                    break
+            if rule_matched:
+                break
+
+        if rule_matched:
+            body = strip_frontmatter(content)
+            matched.append((str(rule_file), body))
+
+    return matched
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: match-rules.py <changed-files.txt>", file=sys.stderr)
+        sys.exit(1)
+
+    changed_files_path = sys.argv[1]
+    rules_dir = Path(".claude/rules")
+
+    with open(changed_files_path) as f:
+        changed_files = [line.strip() for line in f if line.strip()]
+
+    if not changed_files:
+        print("<!-- no-matching-rules -->")
+        return
+
+    matched = match_rules(changed_files, rules_dir)
+
+    if not matched:
+        print("<!-- no-matching-rules -->")
+        return
+
+    # マッチしたルールのサマリー
+    print(f"マッチしたルール: {len(matched)} 件\n")
+    for path, _ in matched:
+        print(f"- `{path}`")
+    print()
+
+    # 各ルールの本文
+    for path, body in matched:
+        print(f"### {path}\n")
+        print(body)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-rules-check.yaml
+++ b/.github/workflows/claude-rules-check.yaml
@@ -151,9 +151,43 @@ jobs:
             echo "REVIEW_MODE_EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Get changed files
+        id: changed-files
+        if: steps.check-draft.outputs.is_draft == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}
+          gh pr diff "$PR_NUMBER" --name-only > /tmp/changed-files.txt
+
+      - name: Match rules to changed files
+        id: match-rules
+        if: steps.check-draft.outputs.is_draft == 'false'
+        run: |
+          {
+            echo "MATCHED_RULES<<EOF_MATCHED_RULES"
+            python3 .github/scripts/match-rules.py /tmp/changed-files.txt
+            echo "EOF_MATCHED_RULES"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report skipped status for no matching rules
+        if: >
+          steps.check-draft.outputs.is_draft == 'false' &&
+          contains(steps.match-rules.outputs.MATCHED_RULES, '<!-- no-matching-rules -->')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "$STATUS_URL" \
+            -f state=success \
+            -f context="Claude Rules Check" \
+            -f description="Skipped (no matching rules)" \
+            -f target_url="$RUN_URL" || true
+
       - name: Run Claude Rules Check
         id: check
-        if: steps.check-draft.outputs.is_draft == 'false'
+        if: >
+          steps.check-draft.outputs.is_draft == 'false' &&
+          !contains(steps.match-rules.outputs.MATCHED_RULES, '<!-- no-matching-rules -->')
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -192,11 +226,17 @@ jobs:
             この PR が `.claude/rules/` に定義されたルールに準拠しているかチェックする。
             コードの品質や設計に関する詳細なレビューは別のワークフロー（Code Review）で行う。
 
+            ## マッチしたルール
+
+            以下のルールが今回の PR の変更ファイルにマッチしました。
+            ルールファイルを自分で読む必要はありません。以下の内容のみに基づいてチェックしてください。
+
+            ${{ steps.match-rules.outputs.MATCHED_RULES }}
+
             ## 手順
 
-            1. `gh pr diff` で変更されたファイルパスを取得
-            2. `.claude/rules/` 内の各ルールファイルを読み、`paths:` パターンとマッチするか確認
-            3. マッチしたルールファイルの内容に基づいて、変更がルールに準拠しているかチェック
+            1. `gh pr diff` で変更内容を確認
+            2. 上記のマッチしたルールに基づいて、変更がルールに準拠しているかチェック
 
             ## チェック観点
 
@@ -316,8 +356,8 @@ jobs:
               ```
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 40
-            --allowedTools "Read,Bash(cat:*),Bash(grep:*),Bash(find:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
+            --max-turns 20
+            --allowedTools "Read,Bash(cat:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
 
       - name: Check rules result
         id: rules-result


### PR DESCRIPTION
## Issue

Related to #390

## Summary

Rules Check ワークフローのパスマッチングを事前計算することで、Claude の LLM ターン数を大幅に削減する。

### 背景

Rules Check が Auto Review より遅くなることがある原因は、Claude が `.claude/rules/` 内の 19 個のルールファイルを 1 つずつ読んで glob パターンマッチングを手動で行っているため。ファイル I/O の往復（API ラウンドトリップ）が実行時間を支配していた。

### 変更内容

- `.github/scripts/match-rules.py` を新規作成: 変更ファイルと `.claude/rules/` の `paths:` パターンを Python でマッチングし、該当ルールの内容を出力
- ワークフローに「Get changed files」「Match rules」ステップを追加: マッチしたルールの内容をプロンプトに直接埋め込み
- Claude の `--max-turns` を 40→20 に削減（ルールファイル読み取りが不要になったため）
- `--allowedTools` から `Bash(grep:*)` と `Bash(find:*)` を削除（ルール探索が不要）
- マッチするルールが 0 件の場合、Claude を呼ばずにスキップ

### 期待される効果

- Claude のターン数: ~10-20 → ~3-7（ルールファイル読み取りが不要）
- マッチ 0 件時は API コスト節約
- Auto Review と同等以下の所要時間

## Self-review

- 設計・ドキュメント: N/A（CI ワークフローの最適化）
- Issue との整合: #390 の責務分離を維持しつつパフォーマンスを改善
- テスト: ローカルで match-rules.py を複数パターンで検証済み
- コード品質（マイナス→ゼロ）: 既存ワークフロー構造を維持、新ステップは既存パターン準拠
- 品質向上（ゼロ→プラス）: 決定論的処理（glob マッチング）を LLM から分離し適切な実行環境に配置
- UI/UX: N/A
- 横断検証: N/A（単一ワークフロー）
- `just check-all` pass: pre-push hooks 全テスト通過

## Test plan

- [x] ローカルで `match-rules.py` を `.rs` ファイル、`.elm` + `.spec.ts` ファイル、`justfile`、空ファイルでテスト
- [ ] PR 作成後、Rules Check ワークフローが正常に実行されることを確認
- [ ] 実行時間を以前の実行と比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)