### PR TITLE
#862 Add rust-script test automation to just check

### DIFF
--- a/justfile
+++ b/justfile
@@ -301,7 +301,7 @@ lint-openapi:
 # =============================================================================
 
 # 全テスト（単体テストのみ）
-test: test-rust test-elm
+test: test-rust test-elm test-rust-scripts
 
 # Rust 単体テスト + doctest
 test-rust:
@@ -315,6 +315,13 @@ test-rust-integration:
 # Elm テスト
 test-elm:
     cd frontend && pnpm run test
+
+# rust-script ユニットテスト（Cargo workspace 外の独立スクリプト）
+test-rust-scripts:
+    rust-script --test ./scripts/check/instrumentation.rs
+    rust-script --test ./scripts/check/improvement-records.rs
+    rust-script --test ./scripts/check/impl-docs.rs
+    rust-script --test ./scripts/issue/sync-epic.rs
 
 # Elm ビルドチェック（コンパイルエラー検出）
 # lint-elm や test-elm ではコンパイルエラーを検出できないため、

--- a/scripts/check/parallel.sh
+++ b/scripts/check/parallel.sh
@@ -31,6 +31,7 @@ trap 'rm -f "$non_rust_log"' EXIT
     set -e
     just lint-elm
     just test-elm
+    just test-rust-scripts
     just build-elm
     just lint-shell
     just lint-ci


### PR DESCRIPTION
## Summary

rust-script で移行した4スクリプトのユニットテスト（計67個）を `just check` の実行パスに組み込む。

- justfile に `test-rust-scripts` レシピを追加（`rust-script --test` で4スクリプトを実行）
- `test` aggregate レシピに追加
- `parallel.sh` の Non-Rust レーンに追加

## Related

Closes #862
Related to #841

## Test plan

- [x] `just test-rust-scripts` で4スクリプト計67テストが通過
- [x] `just check-all` が正常終了（exit code 0）

## Self-review

- 設計・ドキュメント: N/A（DX 改善、設計書該当なし）
- Issue との整合: 完了基準2件達成、`just check` と CI 両方で自動実行される
- テスト: N/A（既存テストの実行パス追加のみ）
- コード品質（マイナス→ゼロ）: 既存パターン準拠（parallel.sh の Non-Rust レーンに配置）
- 品質向上（ゼロ→プラス）: N/A（最小限の変更）
- UI/UX: N/A
- 横断検証: N/A（単一変更）
- `just check-all` pass: 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)