### PR TITLE
#795 Add DOM timing caveat to Elm Ports knowledge base

### DIFF
--- a/docs/06_ナレッジベース/elm/SVGキャンバスとBrowserEvents.md
+++ b/docs/06_ナレッジベース/elm/SVGキャンバスとBrowserEvents.md
@@ -108,6 +108,8 @@ app.ports.requestCanvasBounds.subscribe((elementId) => {
 
 `requestAnimationFrame` を使う理由: Elm の Virtual DOM 更新が完了してから DOM 情報を取得するため。
 
+注意: 条件付きレンダリング（RemoteData の Loading 中等）でキャンバス要素が DOM に存在しない場合、`getElementById` が `null` を返す。Port コマンドの発行タイミングに注意すること。→ [Elm Ports: DOM 依存の Ports コマンドとタイミング](Elmポート.md#dom-依存の-ports-コマンドとタイミング)
+
 ## SVG レイヤー順序
 
 SVG は後に記述した要素が前面に描画される（z-index なし）。インタラクティブなキャンバスでは描画順序がイベント伝播に影響する。


### PR DESCRIPTION
## Issue

Closes #795

## Summary

Elm Ports ナレッジベースに、RemoteData 状態変化と DOM 依存 Ports コマンドのタイミング問題に関する注意事項を追記した。

#793 で発覚した「Loading 中に DOM 依存の Port コマンドを発行すると `getElementById` が `null` を返す」パターンを、再発防止のための知識として記録。SVG キャンバスのナレッジベースにも相互参照を追加した。

注: Issue の対応案 1（ギャップ発見の「状態網羅漏れ」を view + Cmd に拡張）は PR #798 で実施済み。本 PR は対応案 2（ナレッジベースへの注意点追記）を実施。

## Self-review

- 参照の網羅性: `Elmポート.md` から ADR-054、SVG キャンバス KB、#793/#794 への参照を追加。`SVGキャンバスとBrowserEvents.md` から `Elmポート.md` への相互参照を追加
- 用語の統一: 「DOM 依存の Ports コマンド」で統一、既存のナレッジベースの文体に準拠
- 意図の明確さ: 問題・原因・対処法・判定基準・根本対策を構造化して記載
- `just check-all` pass: 全テスト通過

## Test plan

- [x] `just check-all` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)