### PR TITLE
#930 Clarify PR template compliance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,7 +279,7 @@ lefthook により、ブランチ名が `feature/34-xxx` 形式なら Issue 番�
 PR 本文の形式:
 - 先頭に `## Issue` セクション: Story PR は `Closes #<Story番号>`、参照のみは `Related to #123`
 - Epic に対して `Closes` は使用しない
-- AI エージェントは `--body` で本文を直接指定し、末尾に署名: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+- AI エージェントは PR テンプレート（`.github/pull_request_template.md`）の構造に沿った本文を `--body` で直接指定し、末尾に署名: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
 
 **禁止:**
 


### PR DESCRIPTION
## Issue

Closes #930

## 概要

CLAUDE.md の PR 本文ルールに、PR テンプレート準拠を明示する。`--body` の使用方法（How）のみの記述に、テンプレート構造に沿うこと（What）を追加する。

## 品質確認

- 参照の網羅性: CLAUDE.md の該当箇所のみ修正。`dev-flow-issue.md` L103 と `start/SKILL.md` は既にテンプレート参照が記述済みで変更不要
- 用語の統一: 「PR テンプレート（`.github/pull_request_template.md`）」— `dev-flow-issue.md` L103 と同じ表現を使用
- 意図の明確さ: What（テンプレート準拠）と How（`--body`）を両方明示する修正
- `just check-all` pass: 全テスト通過（ユニット、API 40/40、E2E 21/21）

## 確認項目

- [x] `just check-all` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)