### PR TITLE
Fix As-Is verification timing to use latest origin/main

### DIFF
--- a/.claude/rules/dev-flow-issue.md
+++ b/.claude/rules/dev-flow-issue.md
@@ -43,9 +43,15 @@ flowchart LR
 
 Issue 本文の現状分析は作成時点の仮説。着手時に最新の As-Is で検証する。
 
+前提: コード実測の前に `origin/main` を最新化する。
+
+```bash
+git fetch origin main
+```
+
 1. `gh issue view <number> --json createdAt` で作成日時を確認
 2. `gh pr list --search "#<Issue番号>"` で作成後の関連 PR を検索
-3. 最新の As-Is を実測・確認（Issue 本文を鵜呑みにしない）
+3. 最新の As-Is を `origin/main` 基準で実測・確認（Issue 本文を鵜呑みにしない）
 4. Issue の前提が現在も有効か判断
 
 → 詳細: [問題解決フレームワーク > Issue 精査時の As-Is 確認](problem-solving.md#issue-精査時の-as-is-確認)
@@ -89,10 +95,15 @@ EOF
 
 ## 2. ブランチ作成
 
-ブランチ作成前に main を最新化する:
+ブランチ作成前に main を最新化し、最新 main からブランチを作成する:
 
 ```bash
+# 通常
 git checkout main && git pull origin main
+
+# worktree 等で main がロックされている場合
+git fetch origin main
+git checkout -b <branch-name> origin/main
 ```
 
 命名規則:

--- a/.claude/rules/problem-solving.md
+++ b/.claude/rules/problem-solving.md
@@ -33,9 +33,11 @@ Issue 本文の現状分析は「作成時点の仮説」。着手時に最新�
 
 確認手順:
 
+前提: コード実測の前に `git fetch origin main` で `origin/main` を最新化する。
+
 1. Issue 作成日時を確認（`gh issue view <number> --json createdAt`）
 2. 作成後の関連 PR を検索（`gh pr list --search "#<Issue番号>"`）
-3. 最新の As-Is を測定・確認（可能な限り実測で検証）
+3. 最新の As-Is を `origin/main` 基準で実測・確認（可能な限り実測で検証）
 4. Issue の前提が現在も有効か判断
    - 既に改善済み → 残る課題を特定、Issue クローズを提案
    - まだ未改善 → Issue の現状分析を信頼して進める


### PR DESCRIPTION
## Issue

なし（プロセス改善）

## 概要

Issue 精査の As-Is 検証で、コード実測の前提条件として `git fetch origin main` を追加し、最新の `origin/main` を基準に検証するよう修正。
ブランチ作成手順に worktree 環境でのパスも追加。

## 背景

従来のフローでは `git pull origin main` がステップ 2（ブランチ作成）にあり、ステップ 1（Issue 精査）の As-Is 検証時にはローカルの古い main を参照するリスクがあった。
また、worktree 環境では main がロックされ `git checkout main` が実行できないケースがある。

`git fetch origin main` は worktree でも通常環境でも安全に動作し、`origin/main` を最新化できるため、As-Is 検証の前提条件として適切。

## 品質確認

- 参照の網羅性: `dev-flow-issue.md` と `problem-solving.md` の両方で As-Is 検証手順を更新
- 用語の統一: `origin/main` 基準を両ファイルで統一的に使用
- 意図の明確さ: 「前提」として明示し、コード実測の前に実行すべきことが読み取れる
- `just check-all` pass: Markdown のみの変更のため N/A（pre-push hook は通過）

## 確認項目

- [x] pre-push hook が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)