### PR TITLE
#975 Fix missing checkout in review workflow finalize jobs

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -564,6 +564,9 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Check review decision
         id: review-decision
         env:

--- a/.github/workflows/claude-rules-check.yaml
+++ b/.github/workflows/claude-rules-check.yaml
@@ -558,6 +558,9 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Determine final status
         id: final-status
         env:


### PR DESCRIPTION
## Issue

Related to #975

## 概要

PR #975 で導入された Claude Auto Review / Rules Check ワークフローの並列化において、Finalize ジョブに `actions/checkout` ステップが欠落していたため、`determine-review-status.sh` / `determine-rules-check-status.sh` スクリプトの実行が「No such file or directory」で失敗していた。

`workflow_run` トリガーのワークフローは default branch (main) の YAML を使用するため、PR #974 のマージがブロックされていた。

## 変更内容

- `claude-auto-review.yaml` の Finalize ジョブに `actions/checkout@v6` ステップを追加
- `claude-rules-check.yaml` の Finalize ジョブに `actions/checkout@v6` ステップを追加

## 品質確認

- 設計・ドキュメント: N/A（CI ワークフローの軽微な修正）
- Issue との整合: #975 のフォローアップ修正
- テスト: N/A（CI ワークフローの動作はマージ後に自動検証）
- コード品質: 他のジョブの checkout パターンに準拠
- `just check-all` pass: N/A（ワークフロー YAML のみの変更）

## 確認項目

- [x] Finalize ジョブで `./scripts/ci/determine-review-status.sh` が実行可能になること
- [x] Finalize ジョブで `./scripts/ci/determine-rules-check-status.sh` が実行可能になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)