### PR TITLE
#994 Fix README numbers and resolve ADR 047 duplication

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -196,7 +196,7 @@ AI エージェント（Claude Code）に開発を主導させながら、品質
 
 ### AI の行動規範
 
-[CLAUDE.md](CLAUDE.md)（約400行）と [23 のルールファイル](.claude/rules/) が AI の行動を構造的に規定している。
+[CLAUDE.md](CLAUDE.md)（約400行）と [26 のルールファイル](.claude/rules/) が AI の行動を構造的に規定している。
 「AI が自由に書く」のではなく、「ルールに従って書く」体制。
 
 主要なルール:
@@ -219,7 +219,7 @@ flowchart LR
     E -.->|次のセッション| A
 ```
 
-現在 [93 件の改善記録](process/improvements/)がある。事例:
+現在 [110 件の改善記録](process/improvements/)がある。事例:
 
 | 事例 | 問題 | 対策 |
 |------|------|------|

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Development is led by an AI agent (Claude Code), with guardrails to ensure quali
 
 ### AI Behavioral Rules
 
-[CLAUDE.md](CLAUDE.md) (~400 lines) and [23 rule files](.claude/rules/) structurally govern the AI's behavior. The AI doesn't write freely — it follows rules.
+[CLAUDE.md](CLAUDE.md) (~400 lines) and [26 rule files](.claude/rules/) structurally govern the AI's behavior. The AI doesn't write freely — it follows rules.
 
 Key rules:
 
@@ -218,7 +218,7 @@ flowchart LR
     E -.->|Next session| A
 ```
 
-Currently [93 improvement records](process/improvements/) exist. Examples:
+Currently [110 improvement records](process/improvements/) exist. Examples:
 
 | Case | Problem | Countermeasure |
 |------|---------|----------------|


### PR DESCRIPTION
## Issue

Closes #994

## 概要

月次健全性診断で検出された README の統計数値を最新化する:
- 改善記録件数: 93 → 110
- ルールファイル数: 23 → 26

ADR 047 の番号重複は PR #1001 で既に解消済み（047_Elm → 061_Elm にリナンバー）。

## 品質確認

- 参照の網羅性: `README.md`、`README.ja.md` の両方を更新。`047_Elm` への参照が残っていないことを Grep で確認
- 用語の統一: 数値のみの変更で用語の変更なし
- 意図の明確さ: ハードコードされた統計数値を実際のファイル数に合わせて更新
- `just check` + CI pass: 全テスト通過

## 確認項目

- [x] `just check` + CI が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)