### PR TITLE
#1060 Fix validation job max-turns failure

### DIFF
--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -581,7 +581,7 @@ jobs:
             ```
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 15
+            --max-turns 25
             --allowedTools "Read,Bash(cat:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
 
   # ──────────────────────────────────────────────

--- a/prompts/runs/2026-03/2026-03-06_0000_Validation-max-turns修正.md
+++ b/prompts/runs/2026-03/2026-03-06_0000_Validation-max-turns修正.md
@@ -1,0 +1,34 @@
+# Validation ジョブの max-turns 修正
+
+## コンテキスト
+
+- Issue: #1060
+- PR: #1061
+- ブランチ: `fix/1060-validation-max-turns`
+
+## 変更内容
+
+`.github/workflows/claude-auto-review.yaml` の Validation ジョブの `max-turns` を 15 → 25 に変更。
+
+## 判断ログ
+
+### max-turns の値: 25
+
+選択肢:
+- A: 20（permission denial 8 + 実質 7 = 15 でギリギリ）
+- B: 25（余裕あり、Verification の 30 より低い）← 採用
+- C: 30（Verification と同じ、過剰）
+
+理由: 失敗時の実測データ（permission_denials: 8, 実質 turns: 8）から、25 あれば denial が発生しても十分な余裕がある。Verification（30）より低く抑え、コスト意識も維持。
+
+### permission denial の根本対応について
+
+Sonnet が `allowedTools` 外のツール（Glob, Grep, Bash(git log:*) 等）を呼び出す問題は、モデルの振る舞いが PR 内容に依存するため完全な予測は困難。max-turns の増加で実質的に対処し、根本対応は経過観察とする。
+
+## 調査データ
+
+| 実行 ID | 結果 | num_turns | permission_denials |
+|---------|------|-----------|-------------------|
+| 22721108376 | success | 7 | 0 |
+| 22721593438 | failure | 16 | 8 |
+| 22721922211 | failure | - | 8 |


### PR DESCRIPTION
## Issue

Closes #1060

## 概要

Claude Auto Review の Validation ジョブが `max-turns: 15` に到達して failure になる問題を修正。
permission denial のリトライで turns が消費され、レビュー結果自体は APPROVED でもワークフローステータスが FAILURE になっていた。
`max-turns` を 15 → 25 に増加し、permission denial のオーバーヘッドに対する余裕を確保した。

## 品質確認

- 設計・ドキュメント: セッションログ `prompts/runs/2026-03/2026-03-06_0000_Validation-max-turns修正.md`。ADR 該当なし（既存設定の値変更のみ）
- Issue との整合: max-turns 増加（対応案1）を実施。permission denial 原因は調査済みで、モデル依存のため max-turns 増加が実質的な対策
- テスト: N/A（CI ワークフロー設定の数値変更のみ、ユニットテスト対象外）
- コード品質（マイナス→ゼロ）: Verification の max-turns: 30 との整合性確認済み（25 < 30 で適切）
- 品質向上（ゼロ→プラス）: N/A（設定値変更のみ）
- UI/UX: N/A（バックエンド CI のみ）
- 横断検証: N/A（単一ファイル変更）
- `just check` + CI pass: S3 統合テストの失敗は MinIO 未起動による既存問題で本変更と無関係

## 確認項目

- [x] 変更が `.github/workflows/claude-auto-review.yaml` の `max-turns` のみであること
- [x] 失敗した実行のデータ分析に基づく値設定（permission_denials: 8, 実質 turns: 8 → 25 で十分）

🤖 Generated with [Claude Code](https://claude.com/claude-code)