### PR TITLE
Fix S3 dispatch failure on Lightsail by adding missing AWS_REGION

### DIFF
--- a/infra/lightsail/docker-compose.yaml
+++ b/infra/lightsail/docker-compose.yaml
@@ -95,6 +95,7 @@ services:
       S3_BUCKET_NAME: ringiflow-dev-documents
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: ap-northeast-1
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## 概要

Lightsail デモ環境の Core Service で S3 Presigned URL 生成が `dispatch failure` エラーで失敗する問題を修正。

## Issue

Related to なし（デモ環境の運用バグ）

## 原因

`infra/lightsail/docker-compose.yaml` の core-service に `AWS_REGION` 環境変数が未設定だった。
AWS SDK for Rust がリージョンを IMDS から取得しようとするが、Docker の `internal: true` ネットワーク上では外部通信がブロックされ、`dispatch failure` が発生。

開発環境（`.env.template`）・CI（`ci.yaml`）・API テスト（`.env.api-test.template`）には設定済みだったが、Lightsail の docker-compose.yaml のみ漏れていた。

## 確認項目

- [x] `AWS_REGION: ap-northeast-1` を core-service の environment に追加
- [x] 他環境（dev, CI, api-test）との整合性を確認

## 品質確認

- 設計・ドキュメント: N/A（インフラ設定の1行追加）
- テスト: N/A（docker-compose.yaml の環境変数追加のみ）
- コード品質: 他環境の設定と整合
- `just check` pass + CI pass: pre-push フック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)