### PR TITLE
Fix ELIFECYCLE noise in E2E test cleanup

### DIFF
--- a/scripts/test/run-e2e.sh
+++ b/scripts/test/run-e2e.sh
@@ -85,7 +85,7 @@ done
 # Vite 開発サーバーを起動（BFF_PORT でプロキシ先を API テスト BFF に向ける）
 echo "Vite 開発サーバーを起動中..."
 cd "$PROJECT_ROOT/frontend"
-VITE_PORT=$E2E_VITE_PORT pnpm run dev &
+VITE_PORT=$E2E_VITE_PORT npx vite &
 
 # Vite 開発サーバーの起動を待機
 cd "$PROJECT_ROOT"


### PR DESCRIPTION
## 概要

E2E テスト完了後の cleanup で表示される `ELIFECYCLE Command failed with exit code 143` ノイズを解消。

## Related

N/A（軽微な改善）

## 変更内容

`run-e2e.sh` で Vite 開発サーバーの起動を `pnpm run dev` から `npx vite` に変更。

pnpm はラップした子プロセスが SIGTERM で終了すると `ELIFECYCLE` メッセージを stdout に出力する。
vite を直接起動することで、pnpm のプロセスマネジメント層を介さず、kill 時のノイズが発生しなくなる。

## 確認項目

- [x] `just check-all` が ELIFECYCLE メッセージなしで全テスト pass
- [x] E2E テスト 26/26 pass
- [x] Vite 起動ログは引き続き表示される（出力抑制ではない）

## 品質確認

- 設計・ドキュメント: N/A（スクリプトの軽微修正）
- テスト: `just check-all` 全テスト pass で確認
- コード品質（マイナス→ゼロ）: 根本原因に対処（出力抑制ではなく pnpm レイヤーの除去）
- `just check-all` pass: 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)