### PR TITLE
Add missing Dependabot labels to setup procedure

### DIFF
--- a/docs/60_手順書/02_プロジェクト構築/03_GitHub設定.md
+++ b/docs/60_手順書/02_プロジェクト構築/03_GitHub設定.md
@@ -526,6 +526,11 @@ Issue を分類するためのラベルを設定する。
 | `priority:low` | 優先度: 低 | 緑 `#0e8a16` |
 | **ステータス** | | |
 | `pending` | 外部要因でブロックされ保留中 | 薄紫 `#D4C5F9` |
+| **Dependabot** | | |
+| `dependencies` | 依存関係の更新 | 青 `#0366d6` |
+| `rust` | Rust / Cargo 依存関係の更新 | オレンジ `#DEA584` |
+| `elm` | Elm / フロントエンド依存関係の更新 | 青 `#1293D8` |
+| `ci` | CI/CD ワークフローの更新 | 緑 `#0E8A16` |
 
 ### 7.2 ラベル作成（CLI）
 
@@ -549,9 +554,14 @@ gh label create "priority:low" --description "優先度: 低" --color "0e8a16"
 
 # ステータス
 gh label create "pending" --description "外部要因でブロックされ保留中" --color "D4C5F9"
+
+# Dependabot（dependabot.yaml で自動付与）
+gh label create "rust" --description "Rust / Cargo 依存関係の更新" --color "DEA584"
+gh label create "elm" --description "Elm / フロントエンド依存関係の更新" --color "1293D8"
+gh label create "ci" --description "CI/CD ワークフローの更新" --color "0E8A16"
 ```
 
-`bug`, `enhancement` はリポジトリ作成時にデフォルトで存在するため、作成不要。
+`bug`, `enhancement`, `dependencies` はリポジトリ作成時にデフォルトで存在するため、作成不要。
 
 ### 7.3 ラベル一括作成（スクリプト）
 

--- a/justfile
+++ b/justfile
@@ -137,6 +137,10 @@ setup-labels:
     @gh label create "priority:low" --description "優先度: 低" --color "0e8a16" 2>/dev/null || echo "  スキップ: priority:low（既存）"
     @# ステータス
     @gh label create "pending" --description "外部要因でブロックされ保留中" --color "D4C5F9" 2>/dev/null || echo "  スキップ: pending（既存）"
+    @# Dependabot（dependabot.yaml で自動付与）
+    @gh label create "rust" --description "Rust / Cargo 依存関係の更新" --color "DEA584" 2>/dev/null || echo "  スキップ: rust（既存）"
+    @gh label create "elm" --description "Elm / フロントエンド依存関係の更新" --color "1293D8" 2>/dev/null || echo "  スキップ: elm（既存）"
+    @gh label create "ci" --description "CI/CD ワークフローの更新" --color "0E8A16" 2>/dev/null || echo "  スキップ: ci（既存）"
     @echo "✓ GitHub ラベルセットアップ完了"
 
 # =============================================================================


### PR DESCRIPTION
## 概要

`dependabot.yaml` で使用している Dependabot 用ラベル（`rust`, `elm`, `ci`）が
GitHub 設定手順書と `just setup-labels` スクリプトに含まれていなかったため追加。
併せて、未作成だった `elm` ラベルと `ci` ラベルをリポジトリに作成し、
`rust` ラベルの色を Rust ブランドカラー（`#DEA584`）に更新。

## Related

Related to #1110（`ci` ラベル未作成の報告元）

## 確認項目

- [x] 手順書のラベル一覧に Dependabot カテゴリを追加
- [x] 手順書の CLI コマンド例に Dependabot ラベルを追加
- [x] `just setup-labels` スクリプトに Dependabot ラベルを追加
- [x] `ci`, `elm` ラベルをリポジトリに作成済み
- [x] `rust` ラベルの色を `#DEA584` に更新済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)