### PR TITLE
Update Rust toolchain from 1.93 to 1.94

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
           components: clippy
 
       # rustfmt の unstable 機能を使用するため nightly が必要
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -246,7 +246,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -468,7 +468,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -590,7 +590,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -788,7 +788,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/claude-rules-check.yaml
+++ b/.github/workflows/claude-rules-check.yaml
@@ -112,7 +112,7 @@ jobs:
         if: steps.check-draft.outputs.is_draft == 'false'
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.93.0
+          toolchain: 1.94.0
 
       - name: Setup sccache
         if: steps.check-draft.outputs.is_draft == 'false'

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,7 @@
 [English version](README.md)
 
 [![CI](https://github.com/ka2kama/ringiflow/actions/workflows/ci.yaml/badge.svg)](https://github.com/ka2kama/ringiflow/actions/workflows/ci.yaml)
-![Rust](https://img.shields.io/badge/Rust-1.93-orange?logo=rust)
+![Rust](https://img.shields.io/badge/Rust-1.94-orange?logo=rust)
 ![Elm](https://img.shields.io/badge/Elm-0.19-60B5CC?logo=elm)
 ![License](https://img.shields.io/badge/License-CC0--1.0-blue)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [日本語版はこちら](README.ja.md)
 
 [![CI](https://github.com/ka2kama/ringiflow/actions/workflows/ci.yaml/badge.svg)](https://github.com/ka2kama/ringiflow/actions/workflows/ci.yaml)
-![Rust](https://img.shields.io/badge/Rust-1.93-orange?logo=rust)
+![Rust](https://img.shields.io/badge/Rust-1.94-orange?logo=rust)
 ![Elm](https://img.shields.io/badge/Elm-0.19-60B5CC?logo=elm)
 ![License](https://img.shields.io/badge/License-CC0--1.0-blue)
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@
 # ============================================================
 # Stage 1: Chef（依存関係の準備）
 # ============================================================
-FROM rust:1.93-slim-bookworm AS chef
+FROM rust:1.94-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \

--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.94.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/docs/60_手順書/01_開発参画/01_開発環境構築.md
+++ b/docs/60_手順書/01_開発参画/01_開発環境構築.md
@@ -11,7 +11,7 @@ RingiFlow の開発に必要なツールをインストールする。
 
 | カテゴリ | ツール | バージョン | 用途 |
 |---------|--------|----------|------|
-| 言語 | Rust | 1.93+ | バックエンド開発 |
+| 言語 | Rust | 1.94+ | バックエンド開発 |
 | ランタイム | Node.js | 22 LTS | フロントエンドビルド |
 | パッケージマネージャー | pnpm | 最新 | フロントエンド依存管理 |
 | 言語 | Elm | 0.19.1 | フロントエンド開発（グローバル） |
@@ -65,10 +65,7 @@ source ~/.cargo/env
 
 ```bash
 rustc --version
-# 出力例: rustc 1.93.0 (xxx)
-
 cargo --version
-# 出力例: cargo 1.93.0 (xxx)
 ```
 
 ### 1.4 追加コンポーネントのインストール
@@ -91,7 +88,6 @@ rustfmt +nightly --version
 # 出力例: rustfmt 1.9.0-nightly (xxx)
 
 cargo clippy --version
-# 出力例: clippy 0.1.93 (xxx)
 ```
 
 ---

--- a/docs/80_ナレッジベース/devtools/GitHubActions.md
+++ b/docs/80_ナレッジベース/devtools/GitHubActions.md
@@ -311,7 +311,7 @@ concurrency:
 | `backend/**/Cargo.toml` | 依存関係、フィーチャー定義、release プロファイル設定 |
 | `backend/Cargo.lock` | ロックされた依存バージョン |
 
-Rust toolchain バージョンは含めない。ci.yaml にピン留め（1.93.0）されており、変更時は通常 Cargo.toml/Cargo.lock も変わるため。
+Rust toolchain バージョンは含めない。ci.yaml にピン留めされており、変更時は通常 Cargo.toml/Cargo.lock も変わるため。
 
 ### restore-keys を使わない理由
 


### PR DESCRIPTION
## 概要

Rust ツールチェインを 1.93.0 から 1.94.0 に更新。
ドキュメント内の冗長なバージョン表記（出力例、括弧内のピン留めバージョン）を削除し、今後の更新時の同期箇所を削減。

## Related

N/A

## 確認項目

- [x] `rust-toolchain.toml` を 1.94.0 に更新
- [x] `Dockerfile` の base image を `rust:1.94-slim-bookworm` に更新
- [x] CI ワークフロー（`ci.yaml`, `claude-rules-check.yaml`）のツールチェインバージョンを更新
- [x] README バッジを更新
- [x] 手順書・ナレッジベースの冗長なバージョン表記を削除
- [x] `just check` 相当の pre-push フック通過

## 品質確認

- 設計・ドキュメント: `docs/60_手順書/01_開発参画/01_開発環境構築.md` 更新済み、`docs/80_ナレッジベース/devtools/GitHubActions.md` 更新済み、ADR該当なし
- テスト: N/A（バージョン更新のみ、既存テスト全通過で確認）
- コード品質（マイナス→ゼロ）: 既存パターン準拠、設定値の一括更新
- 品質向上（ゼロ→プラス）: ドキュメント内の冗長なバージョン表記を削除し保守性向上
- UI/UX: N/A
- `just check` pass + CI pass: pre-push フック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)