### PR TITLE
Migrate pnpm settings to pnpm-workspace.yaml for pnpm 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,8 +330,9 @@ jobs:
         working-directory: frontend
 
       # elm-test は devDependencies、elm と elm-format はグローバル
+      # elm は elm.json の要求バージョンに固定（npm の latest は 0.19.2 系）
       - name: Install Elm tools
-        run: npm install -g elm elm-format
+        run: npm install -g elm@0.19.1 elm-format
 
       - name: Install just
         uses: extractions/setup-just@v4
@@ -617,8 +618,9 @@ jobs:
         with:
           version: 10
 
+      # elm は elm.json の要求バージョンに固定（npm の latest は 0.19.2 系）
       - name: Install Elm
-        run: npm install -g elm
+        run: npm install -g elm@0.19.1
 
       - name: Install cargo-binstall
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.github/workflows/claude-auto-review.yaml
+++ b/.github/workflows/claude-auto-review.yaml
@@ -416,7 +416,7 @@ jobs:
             )"
             ```
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
             --max-turns 30
             --allowedTools "Bash(cat:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),mcp__github_inline_comment__create_inline_comment"
 
@@ -580,7 +580,7 @@ jobs:
             )"
             ```
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
             --max-turns 25
             --allowedTools "Read,Bash(cat:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
 

--- a/.github/workflows/claude-rules-check.yaml
+++ b/.github/workflows/claude-rules-check.yaml
@@ -393,7 +393,7 @@ jobs:
               )"
               ```
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
             --max-turns 15
             --allowedTools "Read,Bash(cat:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
 
@@ -552,7 +552,7 @@ jobs:
               )"
               ```
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-4-8
             --max-turns 15
             --allowedTools "Read,Bash(cat:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
 

--- a/docs/80_ナレッジベース/frontend/pnpm_ビルドスクリプト制限.md
+++ b/docs/80_ナレッジベース/frontend/pnpm_ビルドスクリプト制限.md
@@ -55,33 +55,29 @@ $ pnpm install
 │ Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
 ```
 
-### 設定方法
+### 設定方法（pnpm v11 以降）
 
-`pnpm approve-builds` を実行すると、対話形式で許可/無視を選択できる：
+pnpm v11 で 2 つの変更が入った：
 
-```
-$ pnpm approve-builds
+1. `package.json` の `pnpm` フィールドが読まれなくなった（設定の新しい置き場所は `pnpm-workspace.yaml`）
+2. ビルドスクリプトを持つ依存が未判定のままだと、警告ではなく**インストールがエラー**になる（`ERR_PNPM_IGNORED_BUILDS`）。判定を促すテンプレートが `pnpm-workspace.yaml` に自動生成される
 
-? esbuild@0.27.2 has a build script. Allow it?
-> allow (run the script)
-  ignore (don't run, but don't warn)
-  deny (don't run, and warn if present)
-```
+設定は `pnpm-workspace.yaml` の `allowBuilds` に、パッケージごとの true/false で明示する：
 
-設定は `package.json` の `pnpm` フィールドに保存される：
-
-```json
-{
-  "pnpm": {
-    "neverBuiltDependencies": ["esbuild"]
-  }
-}
+```yaml
+# pnpm-workspace.yaml
+allowBuilds:
+  esbuild: false # スクリプトを実行しない
 ```
 
-| 設定 | 説明 |
-|------|------|
-| `neverBuiltDependencies` | スクリプトを実行しない（警告も出ない） |
-| `onlyBuiltDependencies` | 指定したパッケージのみスクリプトを実行 |
+`pnpm approve-builds` を実行すると、対話形式で許可/拒否を選択して同ファイルに保存できる。
+
+| 設定値 | 説明 |
+|--------|------|
+| `false` | スクリプトを実行しない（エラーも警告も出ない） |
+| `true` | スクリプトの実行を許可する（信頼できるパッケージのみ） |
+
+v10 以前の `neverBuiltDependencies` / `onlyBuiltDependencies`（package.json の `pnpm` フィールド）は廃止された。`overrides` も同様に `pnpm-workspace.yaml` へ移動した。
 
 ## esbuild の場合
 
@@ -108,41 +104,43 @@ esbuild は `optionalDependencies` としてプラットフォーム固有のパ
 ```
 
 pnpm は `postinstall` を実行しなくても、適切なオプショナル依存関係を解決してバイナリを取得できる。
-そのため `neverBuiltDependencies` で問題なく動作する。
+そのため `allowBuilds: esbuild: false` で問題なく動作する。
+
+補足: Vite 8（rolldown ベース）では esbuild はオプショナル peer 依存になったため、依存グラフ自体に現れないことがある。
 
 ## 設定の選択基準
 
-| 設定 | 用途 |
-|------|------|
-| `onlyBuiltDependencies` | 指定したパッケージのみスクリプトを実行 |
-| `neverBuiltDependencies` | 指定したパッケージのスクリプトを実行しない |
-
 判断のポイント:
-1. まず `neverBuiltDependencies` で試す
-2. 動作しなければ `onlyBuiltDependencies` に追加
-3. `onlyBuiltDependencies` にする場合、パッケージの信頼性を確認
+1. まず `false`（実行しない）で試す
+2. 動作しなければ `true` に変更
+3. `true` にする場合、パッケージの信頼性を確認
 
 ## プロジェクトでの運用
 
-本プロジェクトでは `esbuild` を `neverBuiltDependencies` に設定：
+各パッケージルートの `pnpm-workspace.yaml` で設定する：
 
-```json
-// frontend/package.json
-{
-  "pnpm": {
-    "neverBuiltDependencies": ["esbuild"]
-  }
-}
+```yaml
+# frontend/pnpm-workspace.yaml — esbuild のスクリプトを拒否
+allowBuilds:
+  esbuild: false
+```
+
+```yaml
+# pnpm-workspace.yaml（リポジトリルート）— redocly / jscpd の推移的依存を拒否
+allowBuilds:
+  core-js: false
+  protobufjs: false
 ```
 
 理由:
-- esbuild はオプショナル依存関係でバイナリを取得できる
-- 不要なスクリプト実行を避ける
-- `package.json` の設定が最も確実（`.npmrc` は効かないケースがある）
+- いずれもビルドスクリプトなしで動作する（core-js の postinstall は寄付案内の表示のみ）
+- 不要なスクリプト実行を避ける（サプライチェーン攻撃面の最小化）
+
+注意: リポジトリルートに `pnpm-workspace.yaml` を置くと、独自の `pnpm-workspace.yaml` を持たないサブディレクトリはルートのワークスペースに取り込まれる。`frontend/` が独立プロジェクトとして動作するのは `frontend/pnpm-workspace.yaml` が存在するため。
 
 ## 関連リソース
 
-- [pnpm: onlyBuiltDependencies](https://pnpm.io/package_json#pnpmonlybuiltdependencies)
+- [pnpm: Settings](https://pnpm.io/settings)
 - [pnpm v9 リリースノート](https://github.com/pnpm/pnpm/releases/tag/v9.0.0)
 
 ---
@@ -152,3 +150,4 @@ pnpm は `postinstall` を実行しなくても、適切なオプショナル依
 | 日付 | 変更内容 |
 |------|---------|
 | 2026-01-19 | 初版作成 |
+| 2026-07-19 | pnpm v11 対応（`allowBuilds` への移行、`pnpm-workspace.yaml` への設定移動） |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,13 +18,5 @@
     "tailwindcss": "^4.2.3",
     "vite": "^8.0.9",
     "vite-plugin-elm": "^3.0.1"
-  },
-  "pnpm": {
-    "neverBuiltDependencies": [
-      "esbuild"
-    ],
-    "overrides": {
-      "cross-spawn@<6.0.6": "6.0.6"
-    }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1))
+        version: 4.2.4(vite@8.0.9(@types/node@25.0.9)(jiti@2.6.1))
       elm-review:
         specifier: ^2.13.5
         version: 2.13.5
@@ -25,10 +25,10 @@ importers:
         version: 4.2.3
       vite:
         specifier: ^8.0.9
-        version: 8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)
+        version: 8.0.9(@types/node@25.0.9)(jiti@2.6.1)
       vite-plugin-elm:
         specifier: ^3.0.1
-        version: 3.0.1(vite@8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1))
+        version: 3.0.1(vite@8.0.9(@types/node@25.0.9)(jiti@2.6.1))
 
 packages:
 
@@ -40,162 +40,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -257,36 +101,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -360,24 +210,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -582,11 +436,6 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -754,24 +603,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1166,84 +1019,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
-    optional: true
-
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1390,12 +1165,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1))':
+  '@tailwindcss/vite@4.2.4(vite@8.0.9(@types/node@25.0.9)(jiti@2.6.1))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)
+      vite: 8.0.9(@types/node@25.0.9)(jiti@2.6.1)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -1603,36 +1378,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
-    optional: true
 
   fastest-levenshtein@1.0.16: {}
 
@@ -2073,16 +1818,16 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-elm@3.0.1(vite@8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)):
+  vite-plugin-elm@3.0.1(vite@8.0.9(@types/node@25.0.9)(jiti@2.6.1)):
     dependencies:
       acorn: 8.15.0
       acorn-walk: 8.3.4
       elm-esm: 1.1.4
       find-up: 7.0.0
       node-elm-compiler: 5.0.6
-      vite: 8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1)
+      vite: 8.0.9(@types/node@25.0.9)(jiti@2.6.1)
 
-  vite@8.0.9(@types/node@25.0.9)(esbuild@0.27.2)(jiti@2.6.1):
+  vite@8.0.9(@types/node@25.0.9)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2091,7 +1836,6 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.0.9
-      esbuild: 0.27.2
       fsevents: 2.3.3
       jiti: 2.6.1
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# pnpm 11 で package.json の "pnpm" フィールドが廃止されたため、設定をここへ移行。
+# 参照: https://pnpm.io/settings
+
+# esbuild のビルドスクリプトを実行しない（vite が WASM フォールバックで動作）
+allowBuilds:
+  esbuild: false
+
+# cross-spawn の脆弱性対応（ReDoS, GHSA-3xgq-45jj-v275）で 6.0.6 以上に固定
+overrides:
+  cross-spawn@<6.0.6: 6.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm 11 はビルドスクリプトの実行可否の明示（allowBuilds）を要求する。
+# core-js / protobufjs は @redocly/cli, jscpd の推移的依存で、
+# ビルドスクリプトなしで動作するため実行を拒否する（従来挙動の明示化）。
+allowBuilds:
+  core-js: false
+  protobufjs: false

--- a/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
+++ b/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
@@ -45,6 +45,10 @@ PR #1198 の CI で Elm ジョブが `ELM VERSION MISMATCH`（elm.json は 0.19.
 
 CI の E2E ジョブが `Cannot find package '@playwright/test'` で失敗した。frontend と同じ原因（ルートの `pnpm-workspace.yaml` による祖先探索の取り込み）で、`tests/e2e/node_modules` が生成されなくなっていた。`tests/e2e/pnpm-workspace.yaml`（境界マーカー）を追加して解決。
 
+### 追加対応 3: PR レビューワークフローのモデル ID 更新
+
+Ready 化後の Claude Auto Review / Rules Check がコスト 0・1 秒未満で即失敗（再実行でも同様）。ワークフローが `--model claude-opus-4-6` を固定指定しており、実際のモデル呼び出しの最終成功が 7/6、ワークフローは 3/8 から未変更であることから、モデル ID の廃止と判断。`claude-opus-4-8`（現行の Opus）に更新した。
+
 ### 発見事項
 
 - ルートに `pnpm-workspace.yaml` を置くと、独自の workspace ファイルを持たないパッケージルート（`frontend/`, `tests/e2e/`）が祖先探索でルートワークスペースに取り込まれ、install が壊れる。各パッケージルートへの `pnpm-workspace.yaml` 配置が境界として必須

--- a/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
+++ b/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
@@ -37,6 +37,10 @@
 - `frontend` の `pnpm install` 成功、lockfile に `overrides: cross-spawn@<6.0.6: 6.0.6` が復元
 - `just lint-openapi` / `just lint-elm` 通過
 
+### 追加対応: CI の Elm バージョン固定
+
+PR #1198 の CI で Elm ジョブが `ELM VERSION MISMATCH`（elm.json は 0.19.1 要求、CI は 0.19.2）で失敗した。npm の `elm` パッケージの latest が `0.19.2-0` になり、ci.yaml の未固定インストール（`npm install -g elm`）が 0.19.2 を取得したことが原因（ローカルは mise で 0.19.1 固定のため顕在化せず）。ci.yaml の 2 箇所（Elm ジョブ・E2E ジョブ）を `elm@0.19.1` に固定した。Elm 0.19.2 への更新は別途判断する。
+
 ### 発見事項
 
 - ルートに `pnpm-workspace.yaml` を置くと、独自の workspace ファイルを持たない `frontend/` が祖先探索でルートワークスペースに取り込まれ、install が壊れる。`frontend/pnpm-workspace.yaml` の存在が境界として必須

--- a/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
+++ b/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
@@ -41,9 +41,13 @@
 
 PR #1198 の CI で Elm ジョブが `ELM VERSION MISMATCH`（elm.json は 0.19.1 要求、CI は 0.19.2）で失敗した。npm の `elm` パッケージの latest が `0.19.2-0` になり、ci.yaml の未固定インストール（`npm install -g elm`）が 0.19.2 を取得したことが原因（ローカルは mise で 0.19.1 固定のため顕在化せず）。ci.yaml の 2 箇所（Elm ジョブ・E2E ジョブ）を `elm@0.19.1` に固定した。Elm 0.19.2 への更新は別途判断する。
 
+### 追加対応 2: tests/e2e の境界ファイル
+
+CI の E2E ジョブが `Cannot find package '@playwright/test'` で失敗した。frontend と同じ原因（ルートの `pnpm-workspace.yaml` による祖先探索の取り込み）で、`tests/e2e/node_modules` が生成されなくなっていた。`tests/e2e/pnpm-workspace.yaml`（境界マーカー）を追加して解決。
+
 ### 発見事項
 
-- ルートに `pnpm-workspace.yaml` を置くと、独自の workspace ファイルを持たない `frontend/` が祖先探索でルートワークスペースに取り込まれ、install が壊れる。`frontend/pnpm-workspace.yaml` の存在が境界として必須
+- ルートに `pnpm-workspace.yaml` を置くと、独自の workspace ファイルを持たないパッケージルート（`frontend/`, `tests/e2e/`）が祖先探索でルートワークスペースに取り込まれ、install が壊れる。各パッケージルートへの `pnpm-workspace.yaml` 配置が境界として必須
 - pnpm 11 は未判定の依存があると `pnpm-workspace.yaml` に `allowBuilds` のプレースホルダテンプレートを自動生成する（`set this to true or false`）
 
 ## 関連ドキュメント

--- a/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
+++ b/prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md
@@ -1,0 +1,48 @@
+# pnpm 11 設定移行（package.json pnpm フィールド → pnpm-workspace.yaml）
+
+## コンテキスト
+
+- Issue: なし（環境更新に伴う修正。Rust ツールチェイン更新作業中に発見）
+- ブランチ: `chore/pnpm-11-settings-migration`
+- 経緯: Rust 1.97.1 更新の push が pre-push フック（`lint-openapi` / `lint-elm`）で失敗し、原因を調査した結果、pnpm 11 の設定仕様変更への未対応が判明。ユーザーに確認のうえ、別ブランチで先行修正することを選択
+
+## 作業内容
+
+### 背景（pnpm 11 の仕様変更）
+
+1. `package.json` の `pnpm` フィールド（`neverBuiltDependencies`, `overrides`）が読まれなくなった
+2. ビルドスクリプトを持つ依存の実行可否が未判定だと `pnpm install` が `ERR_PNPM_IGNORED_BUILDS` でエラーになる（v10 までは警告のみ）
+
+この結果、この環境ではすべての `pnpm install`（`just lint-openapi` / `lint-elm` が誘発）が失敗し、pre-push フックが全 push をブロックしていた。また `frontend/pnpm-lock.yaml` に `cross-spawn@<6.0.6: 6.0.6` のセキュリティピンが外れたドリフトが発生していた。
+
+### 成果物
+
+1. `pnpm-workspace.yaml`（ルート、新規） — `allowBuilds` で core-js / protobufjs のビルドスクリプトを明示拒否
+2. `frontend/pnpm-workspace.yaml`（新規） — `allowBuilds: esbuild: false` と `overrides`（cross-spawn ピン）を package.json から移行
+3. `frontend/package.json` — 廃止された `pnpm` フィールドを削除
+4. `frontend/pnpm-lock.yaml` — 再生成。cross-spawn の override を復元。esbuild とプラットフォームバイナリ群が依存グラフから外れた（Vite 8 では esbuild がオプショナル peer のため正当）
+5. `docs/80_ナレッジベース/frontend/pnpm_ビルドスクリプト制限.md` — pnpm 11 の `allowBuilds` 仕様に更新
+
+### 判断ログ
+
+| # | 判断 | 選択 | 理由 |
+|---|------|------|------|
+| 1 | ビルドスクリプトの扱い | 全て拒否（`false`） | 従来も実行されていなかった（v9 以降ブロック済み）挙動の明示化。core-js の postinstall は寄付案内表示のみ、esbuild はオプショナル依存でバイナリ取得可能 |
+| 2 | 設定の置き場所 | 各パッケージルートの `pnpm-workspace.yaml` | pnpm 11 の新仕様。ルートに置くだけだと frontend がルートワークスペースに取り込まれて install が壊れるため、frontend には独自ファイルを配置して境界を維持 |
+| 3 | lockfile の esbuild 削除を受容 | 受容 | Vite 8（rolldown ベース）で esbuild はオプショナル peer。`vite build` が esbuild なしで成功することを確認済み |
+
+### 検証
+
+- ルート `pnpm install` 成功（ERR_PNPM_IGNORED_BUILDS 解消）
+- `frontend` の `pnpm install` 成功、lockfile に `overrides: cross-spawn@<6.0.6: 6.0.6` が復元
+- `just lint-openapi` / `just lint-elm` 通過
+
+### 発見事項
+
+- ルートに `pnpm-workspace.yaml` を置くと、独自の workspace ファイルを持たない `frontend/` が祖先探索でルートワークスペースに取り込まれ、install が壊れる。`frontend/pnpm-workspace.yaml` の存在が境界として必須
+- pnpm 11 は未判定の依存があると `pnpm-workspace.yaml` に `allowBuilds` のプレースホルダテンプレートを自動生成する（`set this to true or false`）
+
+## 関連ドキュメント
+
+- ナレッジベース: [pnpm_ビルドスクリプト制限.md](../../../docs/80_ナレッジベース/frontend/pnpm_ビルドスクリプト制限.md)
+- 関連セッションログ: `prompts/runs/2026-07/2026-07-19_2114_Rustツールチェイン1.97.1更新.md`（`chore/update-rust-1.97` ブランチに存在。本ブランチ時点では未マージのためリンクにしない）

--- a/tests/e2e/pnpm-workspace.yaml
+++ b/tests/e2e/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# このファイルは e2e をリポジトリルートのワークスペースから独立させる境界マーカー。
+# ルートの pnpm-workspace.yaml（allowBuilds 設定用）が存在するため、
+# このファイルがないと pnpm の祖先探索で e2e がルートワークスペースに取り込まれ、
+# tests/e2e/node_modules が生成されなくなる。
+packages:
+  - .


### PR DESCRIPTION
## 概要

pnpm 11 の仕様変更（package.json の `pnpm` フィールド廃止、ビルドスクリプト実行可否の明示要求）に対応し、設定を `pnpm-workspace.yaml` へ移行する。あわせて、CI の Elm インストールを elm.json の要求バージョンに固定する。

未対応の状態では全 `pnpm install` が `ERR_PNPM_IGNORED_BUILDS` で失敗し、pre-push フック（`lint-openapi` / `lint-elm`）がすべての push をブロックしていた。また lockfile 再生成時に `cross-spawn@<6.0.6: 6.0.6` のセキュリティピンが外れるドリフトが発生していた。

変更内容:
- ルート `pnpm-workspace.yaml`（新規）: `allowBuilds` で core-js / protobufjs のビルドスクリプトを明示拒否（従来挙動の明示化）
- `frontend/pnpm-workspace.yaml`（新規）: `allowBuilds: esbuild: false` と `overrides`（cross-spawn ピン）を package.json から移行
- `frontend/package.json`: 廃止された `pnpm` フィールドを削除
- `frontend/pnpm-lock.yaml`: 再生成。cross-spawn override を復元。esbuild とプラットフォームバイナリ群は依存グラフから除外（Vite 8 では esbuild がオプショナル peer のため正当）
- `.github/workflows/ci.yaml`: `npm install -g elm` を `elm@0.19.1` に固定（npm の latest が 0.19.2 系になり、elm.json の要求 0.19.1 と不一致で CI の Elm ジョブが失敗していたため）
- `.github/workflows/claude-auto-review.yaml` / `claude-rules-check.yaml`: レビュー用モデルを廃止済みの `claude-opus-4-6` から `claude-opus-4-8` に更新（Ready 後のレビュージョブが即時失敗していたため）
- `tests/e2e/pnpm-workspace.yaml`（新規）: ルートワークスペースからの独立を保つ境界マーカー（欠如すると tests/e2e/node_modules が生成されず E2E が失敗）
- ナレッジベース `pnpm_ビルドスクリプト制限.md` を pnpm 11 仕様に更新

## Related

N/A

## 確認項目

- [x] ルートの `pnpm install` が成功する（ERR_PNPM_IGNORED_BUILDS 解消）
- [x] `frontend` の `pnpm install` が成功し、lockfile に cross-spawn の override が復元されている
- [x] `just lint-openapi` / `just lint-elm` が通過する
- [x] `just check-pre-push`（pre-push フック）が通過する

## 品質確認

- 設計・ドキュメント: ナレッジベース `docs/80_ナレッジベース/frontend/pnpm_ビルドスクリプト制限.md` 更新済み、セッションログ `prompts/runs/2026-07/2026-07-19_2125_pnpm11設定移行.md`、ADR該当なし
- Issue との整合: N/A（Issue なしの環境修正。Rust ツールチェイン更新作業中に発見）
- テスト: N/A（設定ファイルのみ。既存テスト全通過で確認）
- コード品質（マイナス→ゼロ）: cross-spawn のセキュリティピンを復元、ビルドスクリプト拒否を明示化しサプライチェーン攻撃面を維持、CI の Elm バージョンを elm.json と同期
- 品質向上（ゼロ→プラス）: 暗黙だったビルドスクリプト方針とツールバージョンを設定ファイルで形式知化
- UI/UX: N/A（フロントエンドの挙動変更なし）
- 横断検証: N/A（環境設定のみ）
- `just check-pre-push` pass: 全チェック通過（本文の確認項目参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpCe6ehSAM7DXA13TMb2PH
