### PR TITLE
Restore supply chain health for cargo-deny gate

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,18 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
-dependencies = [
- "object",
-]
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -174,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -184,14 +163,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -272,6 +252,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
@@ -499,23 +480,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.13",
- "http 0.2.12",
+ "h2",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -661,7 +636,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -886,16 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown 0.14.5",
- "stacker",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,7 +995,7 @@ checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest",
- "rand 0.9.2",
+ "rand 0.9.5",
  "regex",
  "rustversion",
 ]
@@ -1056,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1563,25 +1528,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1597,16 +1543,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -1752,30 +1688,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1784,7 +1696,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1799,33 +1711,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
@@ -1842,12 +1739,12 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2093,13 +1990,12 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.19"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64",
- "chumsky",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -2111,7 +2007,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "url",
 ]
@@ -2327,15 +2223,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2624,16 +2511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
-dependencies = [
- "ar_archive_writer",
- "cc",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,8 +2522,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.6.2",
+ "rustls",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -2662,10 +2539,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -2683,7 +2560,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2722,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2788,7 +2665,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
@@ -2866,22 +2743,22 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2956,7 +2833,7 @@ dependencies = [
  "http 1.4.0",
  "insta",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.5",
  "redis",
  "reqwest",
  "ringiflow-domain",
@@ -3149,18 +3026,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -3169,7 +3034,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3198,19 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3253,16 +3108,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sec1"
@@ -3500,16 +3345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3754,19 +3589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "stacker"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,7 +3789,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3985,21 +3807,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -4546,7 +4358,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -35,13 +35,29 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chro
 redis = { version = "1.0", features = ["tokio-comp", "connection-manager"] }
 
 # AWS SDK（DynamoDB 監査ログ、S3 ドキュメント管理）
+# default-features = false: デフォルトの `rustls` feature は legacy 接続系
+# （hyper 0.14 + rustls 0.21 + 脆弱な rustls-webpki 0.101）を引き込むため外す。
+# HTTP クライアントはモダン系の `default-https-client`（hyper 1.x + rustls 0.23）を使用する。
 aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-sdk-dynamodb = "1"
-aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-dynamodb = { version = "1", default-features = false, features = [
+    "default-https-client",
+    "rt-tokio",
+] }
+aws-sdk-s3 = { version = "1", default-features = false, features = [
+    "behavior-version-latest",
+    "sigv4a",
+    "http-1x",
+    "default-https-client",
+    "rt-tokio",
+] }
 base64 = "0.22"
 
 # メール通知
-aws-sdk-sesv2 = "1"
+aws-sdk-sesv2 = { version = "1", default-features = false, features = [
+    "sigv4a",
+    "default-https-client",
+    "rt-tokio",
+] }
 lettre = { version = "0.11", default-features = false, features = ["tokio1", "smtp-transport", "builder"] }
 tera = "1"
 

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -63,8 +63,8 @@ wildcards = "allow"
 # 既知の duplicate crate の旧バージョンを skip（上流の移行完了後に削除する）
 #
 # 主な原因:
-# - AWS SDK がまだ hyper 1.x / rustls 0.23 に完全移行していない
 # - sqlx / argon2 が旧 rand (0.8) / getrandom (0.2) エコシステムに依存
+# - AWS SDK 内部の smithy バージョン断層と後方互換 API サーフェス
 # - Windows プラットフォームクレートのバージョン断片化
 skip = [
     # rand / getrandom エコシステム（sqlx, argon2 経由）
@@ -74,24 +74,16 @@ skip = [
     { crate = "rand_chacha@0.3", reason = "rand 0.8 の推移的依存" },
     { crate = "rand_core@0.6", reason = "rand 0.8 の推移的依存" },
     # hyper / HTTP エコシステム（AWS SDK 経由）
-    { crate = "h2@0.3", reason = "AWS SDK が hyper 0.14 経由で依存" },
-    { crate = "http@0.2", reason = "AWS SDK が hyper 0.14 経由で依存" },
-    { crate = "http-body@0.4", reason = "AWS SDK が hyper 0.14 経由で依存" },
-    { crate = "hyper@0.14", reason = "AWS SDK がまだ hyper 1.x に移行していない" },
-    { crate = "hyper-rustls@0.24", reason = "AWS SDK が rustls 0.21 に依存" },
-    # TLS エコシステム（AWS SDK 経由）
-    { crate = "rustls@0.21", reason = "AWS SDK がまだ rustls 0.23 に移行していない" },
-    { crate = "rustls-webpki@0.101", reason = "rustls 0.21 の推移的依存" },
-    { crate = "tokio-rustls@0.24", reason = "rustls 0.21 の推移的依存" },
+    { crate = "http@0.2", reason = "aws-runtime が後方互換 API サーフェスとして旧 http 型に依存" },
+    { crate = "http-body@0.4", reason = "aws-runtime が後方互換 API サーフェスとして旧 http-body 型に依存" },
     # AWS SDK 内部の smithy バージョン断層（aws-sdk-s3 が旧 smithy に依存）
     { crate = "aws-smithy-http@0.62", reason = "aws-sdk-s3 が旧 smithy-http に依存" },
     { crate = "aws-smithy-json@0.61", reason = "aws-sdk-s3 が旧 smithy-json に依存" },
     # 暗号エコシステム（AWS SDK 経由）
     { crate = "crypto-bigint@0.4", reason = "AWS SDK (aws-sigv4 → p256 → elliptic-curve) が旧バージョンに依存" },
     # その他
-    { crate = "hashbrown@0.14", reason = "lettre → chumsky が旧バージョンに依存" },
     { crate = "hashbrown@0.15", reason = "推移的依存のバージョン差異" },
-    { crate = "socket2@0.5", reason = "推移的依存のバージョン差異" },
+    { crate = "redox_syscall@0.5", reason = "parking_lot_core が旧系に依存。Redox OS 限定の薄い shim で Linux ビルドへの機能影響なし（#1163）" },
 ]
 
 # Windows プラットフォームクレートの旧バージョンツリーを一括 skip

--- a/docs/70_ADR/066_サプライチェーン健全性回復のアプローチ選定.md
+++ b/docs/70_ADR/066_サプライチェーン健全性回復のアプローチ選定.md
@@ -1,0 +1,98 @@
+# ADR-066: サプライチェーン健全性回復のアプローチ選定
+
+## ステータス
+
+承認済み
+
+## コンテキスト
+
+Issue #1163 で `cargo deny check` が `advisories FAILED, bans FAILED, licenses FAILED` を返す状態が顕在化した。CI の Security ジョブは Cargo.lock 変更を伴う PR でのみ実行されるため、違反が長期間潜在化し、以下が蓄積していた:
+
+- advisories: aws-lc-sys 0.37.1 の脆弱性 5 件（RUSTSEC-2026-0044〜0048）、rustls-webpki の 4 件（0049 / 0098 / 0099 / 0104、新旧 2 系統に跨がる）、anyhow / crossbeam-epoch / lettre / rand の各 1 件
+- licenses: aws-lc-sys 0.37.1 の `OpenSSL` ライセンス（allow リスト外）
+- bans: redox_syscall の重複
+
+Issue 起票時点では「aws-lc-rs から ring へのクリプトプロバイダ切替」または「ライセンス例外化」の判断が必要と想定されており、本 ADR はその選定を記録する。
+
+実測で判明した重要な事実:
+
+1. aws-lc は AWS SDK（aws-smithy-http-client → rustls 0.23 → aws-lc-rs）経由のみで依存している
+2. 脆弱な rustls-webpki 0.101 は、aws-sdk-* のデフォルト feature `rustls`（legacy 接続系: hyper 0.14 + rustls 0.21）が引き込んでおり、モダン系 `default-https-client`（hyper 1.x + rustls 0.23）と二重に有効だった
+3. aws-lc-sys 0.43.0 でライセンス表現から `OpenSSL` が除去された（0.37.1 の `ISC AND (Apache-2.0 OR ISC) AND OpenSSL` → 0.43.0 では OpenSSL を含まない許可済みライセンスの組み合わせ）
+4. 本プロジェクトのローカル・CI 環境は S3/DynamoDB とも HTTP 接続（MinIO / dynamodb-local）であり、TLS プロバイダの挙動を実環境相当で検証できない
+5. aws-config / aws-sdk-* / aws-smithy-* の新系（aws-config 1.9 以降）は MSRV 1.94.1 を要求し、現行のツールチェインピン 1.94.0 ではビルドできない（ツールチェイン更新は別 PR #1200 で進行中）
+
+## 検討した選択肢
+
+### 選択肢 1: 依存バージョン更新 + legacy 接続系 feature の無効化
+
+`cargo update` で advisory 対象クレート（anyhow / aws-lc-rs / aws-lc-sys / crossbeam-epoch / lettre / rand / rustls-webpki）のみを修正版へ更新し、aws-sdk-* の `default-features = false` で legacy 接続系（`rustls` feature）を外してモダン系（`default-https-client`）に一本化する。クリプトプロバイダは aws-lc-rs のまま。aws-config / aws-sdk-* 本体は MSRV 制約（コンテキスト 5）のため現行バージョンに据え置く。
+
+評価:
+- 利点: 全違反が解消する。TLS プロバイダの挙動が変わらないため本番認証パスへのリスクがない。脆弱な webpki 0.101 チェーンと hyper 0.14 系の重複が依存ツリーから消える。ライセンス例外も不要（aws-lc-sys 0.43 で OpenSSL 消滅）。ツールチェイン更新（#1200）と独立にマージできる
+- 欠点: aws-lc-sys（C ビルド）が残り、ビルド時間と将来の advisory リスクを保持する
+
+### 選択肢 2: rustls クリプトプロバイダを ring に切替
+
+aws-config / aws-sdk-* の default-features を無効化し、`aws-smithy-http-client` の `rustls-ring` feature で HTTP クライアントを明示構築してコンポジションルートで注入する。
+
+評価:
+- 利点: aws-lc が依存ツリーから完全に消え、aws-lc 系の advisory・ライセンス問題が構造的に再発しなくなる。C ビルドが減りビルドが軽くなる
+- 欠点: 本番の TLS スタックを変更するが、ローカル・CI は全て HTTP 接続のため TLS 経路を検証できない（Verification 不能な変更）。credentials provider 等の feature 選定ミスのリスク。コンポジションルートのコード変更が必要
+
+### 選択肢 3: deny.toml に OpenSSL ライセンス例外を追加（バージョン更新のみ）
+
+advisory はバージョン更新で解消し、ライセンスは `licenses.exceptions` で aws-lc-sys に限定した OpenSSL 許可を追加する。
+
+評価:
+- 利点: 差分が最小
+- 欠点: aws-lc-sys 0.43 で OpenSSL ライセンス自体が消滅したため不要になった（起票時点でのみ有効な選択肢）。legacy 接続系の脆弱チェーンが残る
+
+### 比較表
+
+| 観点 | 1: 更新 + legacy 無効化 | 2: ring 切替 | 3: 更新 + 例外 |
+|------|----------------------|-------------|---------------|
+| 全違反の解消 | ○ | ○ | △（webpki 0.101 が残る） |
+| 本番 TLS への影響 | なし | あり（検証不能） | なし |
+| 将来の aws-lc advisory リスク | 残る | 消える | 残る |
+| 変更規模 | Cargo.toml features + lock | features + コード変更 | lock + deny.toml |
+
+## 決定
+
+選択肢 1（依存バージョン更新 + legacy 接続系 feature の無効化）を採用する。
+
+主な理由:
+
+1. 検証可能性: ローカル・CI に TLS 経路がない以上、TLS プロバイダを変更する選択肢 2 は「検証できない変更を本番投入する」ことになり、Verification の原則に反する
+2. aws-lc-sys 0.43 のライセンス変更により、ring 切替の主動機だった OpenSSL ライセンス問題が消滅した
+3. legacy `rustls` feature の無効化により、脆弱チェーン（rustls 0.21 / webpki 0.101 / hyper 0.14）が依存ツリーから構造的に排除され、単なる「今回の advisory 対処」を超えた再発防止になる
+
+選択肢 2 は却下ではなく保留とする。TLS 経路を検証できる環境（ステージング等）が整い、aws-lc 系の advisory が再発した場合に再評価する。
+
+## 帰結
+
+### 肯定的な影響
+
+- `cargo deny check` が全カテゴリ（advisories / bans / licenses / sources）ok
+- 依存ツリーから hyper 0.14 / rustls 0.21 / webpki 0.101 の legacy TLS チェーンが消え、deny.toml の skip リストから TLS/hyper 系 6 エントリを含む 8 エントリを削除（redox_syscall の追加と差し引きで 21 → 13）
+- Security ゲートが信頼できるシグナルとして復帰し、ブロックされていた PR（#1156、#1200）がマージ可能になる
+
+### 否定的な影響・トレードオフ
+
+- aws-lc-sys の C ビルドとビルド時間は残る
+- aws-sdk-* の feature を明示指定したため、SDK 側のデフォルト変更に自動追従しなくなる（バージョン更新時に feature 構成の確認が必要）
+- RustCrypto 0.10/0.11 系の新旧断層（sqlx・argon2 vs aws-sdk-s3）を skip で許容した。上流の移行完了後に skip を削除する
+
+### 関連ドキュメント
+
+- Issue: #1163
+- 設定: `backend/deny.toml`、`backend/Cargo.toml`
+- 関連 ADR: [ADR-033](033_セキュリティスキャニングツールの選定.md)（cargo-deny 採用）
+
+---
+
+## 変更履歴
+
+| 日付 | 変更内容 |
+|------|---------|
+| 2026-07-19 | 初版作成 |

--- a/prompts/runs/2026-07/2026-07-19_2250_cargo-denyサプライチェーン健全性回復.md
+++ b/prompts/runs/2026-07/2026-07-19_2250_cargo-denyサプライチェーン健全性回復.md
@@ -1,0 +1,40 @@
+# cargo-deny サプライチェーン健全性の回復（#1163）
+
+## コンテキスト
+
+- Issue: #1163
+- ブランチ: `fix/1163-cargo-deny-supply-chain`
+- 経緯: Rust 1.97.1 更新 PR（#1200）の CI で Security ジョブ（cargo-deny）が失敗し、既知の #1163 が全 backend PR のブロッカーであることが顕在化。ユーザー確認のうえ着手
+
+## 作業内容
+
+### 成果物
+
+1. `backend/Cargo.lock` — advisory 対象クレートの更新（anyhow 1.0.104 / aws-lc-rs 1.17.3 / aws-lc-sys 0.43.0 / crossbeam-epoch 0.9.20 / lettre 0.11.22 / rand 0.9.5 / rustls-webpki 0.103.13）
+2. `backend/Cargo.toml` — aws-sdk-dynamodb / s3 / sesv2 を `default-features = false` にし、legacy 接続系 feature `rustls`（hyper 0.14 + rustls 0.21 + 脆弱な webpki 0.101 を引き込む）を除外
+3. `backend/deny.toml` — 消滅した legacy チェーンの skip 8 件を削除、redox_syscall@0.5 を理由付きで追加（21 → 13 エントリ）
+4. `docs/70_ADR/066_サプライチェーン健全性回復のアプローチ選定.md` — アプローチ選定（バージョン更新 + legacy feature 無効化 vs ring 切替 vs ライセンス例外）の記録
+
+### 判断ログ
+
+| # | 判断 | 選択 | 理由 |
+|---|------|------|------|
+| 1 | クリプトプロバイダ | aws-lc-rs 維持（ring 切替は保留） | ローカル・CI は全て HTTP 接続で TLS 経路を検証できず、検証不能な本番 TLS 変更を避けた。詳細は ADR-066 |
+| 2 | OpenSSL ライセンス | 対応不要と判明 | aws-lc-sys 0.43.0 でライセンス表現から OpenSSL が除去されていた（実測で発見） |
+| 3 | webpki 0.101 の脆弱性 3 件 | aws-sdk-* の legacy `rustls` feature を無効化して構造的に排除 | 0.101 系に修正版が存在せず、バージョン更新では解決不能。デフォルト feature が legacy とモダンの接続系を二重に有効化していた |
+| 4 | aws-config / aws-sdk-* 本体 | main 時点のバージョンに据え置き | 新系（aws-config 1.9+）は MSRV 1.94.1 を要求し、現行ピン 1.94.0 でビルド不能。#1200（1.97.1）との相互依存を避け、本 PR を単独マージ可能に保つ |
+
+### 調査過程の学び
+
+- 途中で Cargo.lock が意図せず main 状態へ巻き戻る事象が発生。MSRV 非対応バージョン（aws 1.9 系）を含む lock に対して、resolver v3（edition 2024、MSRV 考慮）の再解決が走ったためと推定。MSRV 互換のみで構成した最終 lock では再発せず
+- cargo-deny の `unmatched-skip` 警告が deny.toml の鮮度を保つラチェットとして機能する（消滅した重複の skip を放置すると警告される）
+
+### 検証
+
+- `cargo deny check` → advisories / bans / licenses / sources すべて ok、unmatched-skip 警告ゼロ
+- `AWS_REGION=ap-northeast-1 just check` で全テスト通過（統合テスト含む）
+
+## 関連ドキュメント
+
+- ADR: [066_サプライチェーン健全性回復のアプローチ選定.md](../../../docs/70_ADR/066_サプライチェーン健全性回復のアプローチ選定.md)
+- Issue 精査コメント: #1163


### PR DESCRIPTION
## Issue

Closes #1163

## 概要

`cargo deny check` の全カテゴリ失敗（advisories 12 件 / licenses / bans）を解消し、CI の Security ゲートを信頼できるシグナルとして復帰させる。

アプローチ（詳細は ADR-066）:
- advisory 対象クレートのみを semver 互換更新（anyhow / aws-lc-rs / aws-lc-sys / crossbeam-epoch / lettre / rand / rustls-webpki）
- aws-sdk-dynamodb / s3 / sesv2 を `default-features = false` にし、legacy 接続系 feature `rustls`（hyper 0.14 + rustls 0.21 + 修正版が存在しない脆弱な rustls-webpki 0.101 を引き込む）を構造的に排除。HTTP クライアントはモダン系 `default-https-client`（hyper 1.x + rustls 0.23）に一本化
- aws-config / aws-sdk-* 本体は据え置き（新系は MSRV 1.94.1 > 現行ピン 1.94.0。ツールチェイン更新は #1200 で別途進行中のため、本 PR は独立してマージ可能に保つ）
- deny.toml: 消滅した legacy チェーンの skip 8 件を削除、redox_syscall@0.5（Redox OS 限定 shim、Linux ビルドへの機能影響なし）を理由付きで追加

判明した副次的事実:
- aws-lc-sys 0.43.0 でライセンス表現から `OpenSSL` が除去されており、起票時に想定されていた「クリプトプロバイダ切替 or ライセンス例外化」の判断は不要になった（ring 切替は保留として ADR-066 に記録）

```mermaid
flowchart LR
    subgraph before["変更前（二重の接続系）"]
        SDK1["aws-sdk-*"] -->|"feature: rustls (legacy)"| Old["hyper 0.14 + rustls 0.21 + webpki 0.101 (脆弱・修正版なし)"]
        SDK1 -->|"feature: default-https-client"| New1["hyper 1.x + rustls 0.23"]
    end
    subgraph after["変更後"]
        SDK2["aws-sdk-* (default-features = false)"] -->|"feature: default-https-client"| New2["hyper 1.x + rustls 0.23 + webpki 0.103.13"]
    end
```

## 確認項目

- [x] `cargo deny check` が advisories / bans / licenses / sources すべて ok（unmatched-skip 警告ゼロ）
- [x] 依存ツリーから hyper 0.14 / rustls 0.21 / rustls-webpki 0.101 が消えている
- [x] `AWS_REGION=ap-northeast-1 just check` で全テスト通過（統合テスト含む）
- [x] pre-push フック（`just check-pre-push`）通過

## 品質確認

- 設計・ドキュメント: ADR `docs/70_ADR/066_サプライチェーン健全性回復のアプローチ選定.md` 作成、セッションログ `prompts/runs/2026-07/2026-07-19_2250_cargo-denyサプライチェーン健全性回復.md`、Issue 精査コメント記録済み
- Issue との整合: 完了条件 1（deny 全カテゴリ ok）と 2（ADR 記録)を達成。条件 3（#1156 の green 化）はマージ後にリベースで検証
- テスト: N/A（依存更新のみ。既存テスト全層の通過で確認、コード変更なし）
- コード品質（マイナス→ゼロ）: 脆弱チェーンの構造的排除（今回限りの対処ではなく feature 構成で再発防止）、deny.toml の skip を実態と同期
- 品質向上（ゼロ→プラス）: skip リストを 21 → 13 エントリに削減し、duplicate ラチェットの精度を向上
- UI/UX: N/A（バックエンド依存のみ）
- 横断検証: N/A（単一関心事）
- `just check` pass + CI pass: ローカル全通過、CI は本 PR で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpCe6ehSAM7DXA13TMb2PH